### PR TITLE
kaggle notebook

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""tpcve — batch + analyze + predict + plots (локальный запуск).
+
+Запуск методов (voxel/chm/alpha/percentile/count) по dataset-спискам,
+вместе и раздельно по стадиям роста --stage Z31/Z65.
+
+Каждый запуск: batch (признак по облакам) → analyze (регрессия biomass ~ признак).
+После — predict-демо + сводные графики.
+
+Требования: uv sync (или pip install -e .).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Полный пайплайн batch + analyze + predict + plots")
+    p.add_argument("--stages", default=None,
+                   help="Стадии через запятую: combined, Z31, Z65 — каждая запускается отдельно (по умолчанию combined,Z31,Z65)")
+    p.add_argument("--workers", type=int, default=2,
+                   help="Число воркеров для batch.py (default: 2)")
+    return p.parse_args(argv)
+
+
+def _setup() -> tuple[Path, Path, Path, Path]:
+    REPO_DIR = Path.cwd().resolve()
+    print("REPO_DIR:", REPO_DIR)
+
+    try:
+        import tpcve  # noqa: F401
+    except ImportError:
+        print("tpcve не импортируется — uv sync или pip install -e .")
+        raise SystemExit(1)
+
+    DATA = Path(os.getenv("TPCVE_DATA_DIR",
+                          "datasets/yanco-2019-wheat-pcd/data/Yanco_TC_2019_HI-pcd"))
+    TRAIN_LIST = DATA.parent / "train_list.txt"
+    TEST_LIST = DATA.parent / "test_list.txt"
+
+    for p in (TRAIN_LIST, TEST_LIST):
+        assert p.exists(), f"нет файла: {p}"
+
+    return REPO_DIR, DATA, TRAIN_LIST, TEST_LIST
+
+
+def _run_batch(method, stage, train_list, test_list, data, repo_dir, workers, *method_flags, **kwargs):
+    """Запустить batch.py для одного метода/стадии (train+test, analyze в цепочке)."""
+    cmd = [
+        sys.executable, "batch.py",
+        "--method", method,
+        "--list", str(train_list),
+        "--list-test", str(test_list),
+        "--base-dir", str(data),
+        "--workers", str(workers),
+        *method_flags,
+    ]
+    if stage is not None:
+        cmd.extend(["--stage", stage])
+    print("\n$ " + " ".join(cmd) + "\n")
+    p = subprocess.run(cmd, cwd=repo_dir, **kwargs)
+    if p.returncode:
+        raise SystemExit(f"batch завершился с кодом {p.returncode}")
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    if args.stages is None:
+        stages = [None, "Z31", "Z65"]
+    else:
+        stages = [s.strip().upper() for s in args.stages.split(",") if s.strip()]
+        stages = [None if s == "COMBINED" else s for s in stages]
+
+    repo_dir, data, train_list, test_list = _setup()
+    results_dir = repo_dir / "results"
+
+    def r(m, s, *f):
+        _run_batch(m, s, train_list, test_list, data, repo_dir, args.workers, *f)
+
+    # 4. Воксельный метод
+    voxel_cfg = "--voxel-sizes", "10,15,20,25,30,35,40,45"
+    for s in stages:
+        r("voxel", s, *voxel_cfg)
+
+    # 5. CHM (объём по сетке высот)
+    chm_cfg = "--cell-sizes", "10,15,20,25", "--percentiles", "1,5,10,50,75,95,99"
+    for s in stages:
+        r("chm", s, *chm_cfg)
+
+    # 6. Послойная альфа-форма
+    alpha_cfg = (
+        "--voxel-sizes", "10,20,30,40,50",
+        "--alphas", "20,30,40",
+        "--layer-dz", "10,20,30,40,50,60",
+        "--no-inner-progress",
+    )
+    for s in stages:
+        r("alpha", s, *alpha_cfg)
+
+    # 7. Бейзлайны
+    for s in stages:
+        r("count", s)
+    for s in stages:
+        r("percentile", s, "--percentiles", "1,5,10,50,75,95,99")
+
+    # 8. Результаты
+    print("\nregression CSV:")
+    for p in sorted(results_dir.glob("regression_csv/**/*.csv")):
+        print(" ", p.relative_to(results_dir))
+    print("\nsummary plots:")
+    for p in sorted(results_dir.glob("figures/summary/*.png")):
+        print(" ", p.relative_to(results_dir))
+
+    # 9. Предсказание биомассы (демо)
+    reg = results_dir / "regression_csv"
+
+    def pick_csv(method, stage):
+        cands = [p for p in (reg / method).glob("*.csv")
+                 if not p.stem.endswith("_test")
+                 and (f"_{stage}_" in f"_{p.stem}_" if stage
+                      else ("_Z31_" not in p.stem and "_Z65_" not in p.stem))]
+        assert len(cands) == 1, f"{method}/{stage}: ожидал 1 CSV, нашёл {len(cands)}: {cands}"
+        return cands[0]
+
+    for stage in stages:
+        label = stage or "combined"
+        print("\n" + "=" * 70)
+        print(f"=== predict: stage={label} ===")
+        print("=" * 70)
+        cmd = [
+            sys.executable, "scripts/predict_biomass.py",
+            "--list", str(test_list),
+            "--base-dir", str(data),
+            "--voxel-csv",  str(pick_csv("voxel", stage)),
+            "--alpha-csv",  str(pick_csv("alpha", stage)),
+            "--chm-csv",    str(pick_csv("chm", stage)),
+            "--height-csv", str(pick_csv("percentile", stage)),
+            "--count-csv",  str(pick_csv("count", stage)),
+        ]
+        print("\n$ " + " ".join(cmd) + "\n")
+        p = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True)
+        print(p.stdout, end="")
+        if p.stderr:
+            print(p.stderr, end="")
+        if p.returncode:
+            raise SystemExit(f"predict (stage={stage}) завершился с кодом {p.returncode}")
+
+    # 10. Сводные графики
+    summary_dir = results_dir / "figures" / "summary"
+    stages_str = ",".join(s or "combined" for s in stages)
+    subprocess.run([
+        sys.executable, "scripts/plot_summary.py",
+        "--results-dir", str(results_dir),
+        "--output-dir", str(summary_dir),
+        "--stages", stages_str,
+    ], cwd=repo_dir, check=True)
+
+    for s in [s or "combined" for s in stages]:
+        png = summary_dir / f"r2_stage_{s}.png"
+        if png.exists():
+            print(f"\nStage: {s} -> {png}")
+
+    best_dir = summary_dir / "best_fits"
+    if best_dir.is_dir():
+        for png in sorted(best_dir.glob("*.png")):
+            print(f"  {png}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -37,7 +37,7 @@
     "REPO_DIR = \"/kaggle/working/tpcve\"\n",
     "\n",
     "if not os.path.isdir(os.path.join(REPO_DIR, \".git\")):\n",
-    "    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", \"--branch\", \"kaggle-notebook\", REPO_URL, REPO_DIR], check=True)\n",
+    "    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", REPO_URL, REPO_DIR], check=True)\n",
     "else:\n",
     "    print(\"repo already cloned\")\n",
     "\n",
@@ -134,8 +134,23 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STAGES = [None, \"Z31\", \"Z65\"]\n",
+    "\n",
+    "# STAGES = [None]          # только combined\n",
+    "# STAGES = [\"Z31\"]         # только Z31\n",
+    "# STAGES = [\"Z65\"]         # только Z65\n",
+    "# STAGES = [\"Z31\", \"Z65\"]  # раздельно две стадии"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
    "metadata": {},
    "source": [
     "## 4. Воксельный метод\n",
@@ -146,36 +161,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"voxel\", None, \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"voxel\", \"Z31\", \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"voxel\", \"Z65\", \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
+    "for s in STAGES:\n",
+    "    run_batch(\"voxel\", s, \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 5. CHM (объём по сетке высот)\n",
@@ -186,36 +182,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"chm\", None, \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"chm\", \"Z31\", \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"chm\", \"Z65\", \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
+    "for s in STAGES:\n",
+    "    run_batch(\"chm\", s, \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "13",
    "metadata": {},
    "source": [
     "## 6. Послойная альфа-форма\n",
@@ -226,61 +203,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#env = {**os.environ, \"TQDM_MININTERVAL\": \"30\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"alpha\", None,\n",
-    "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
-    "          \"--alphas\", \"20,30,40\",\n",
-    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",)\n",
-    "        #   env=env)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"alpha\", \"Z31\",\n",
-    "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
-    "          \"--alphas\", \"20,30,40\",\n",
-    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",)\n",
-    "        #   env=env)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_batch(\"alpha\", \"Z65\",\n",
-    "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
-    "          \"--alphas\", \"20,30,40\",\n",
-    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",)\n",
-    "        #   env=env)"
+    "for s in STAGES:\n",
+    "    run_batch(\"alpha\", s,\n",
+    "              \"--voxel-sizes\", \"10,20,30,40,50\",\n",
+    "              \"--alphas\", \"20,30,40\",\n",
+    "              \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "              \"--no-inner-progress\",)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "15",
    "metadata": {},
    "source": [
     "## 7. Бейзлайны\n",
@@ -291,30 +228,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"count\", None)\n",
-    "run_batch(\"count\", \"Z31\")\n",
-    "run_batch(\"count\", \"Z65\")"
+    "for s in STAGES:\n",
+    "    run_batch(\"count\", s)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"percentile\", None, \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
-    "run_batch(\"percentile\", \"Z31\", \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
-    "run_batch(\"percentile\", \"Z65\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
+    "for s in STAGES:\n",
+    "    run_batch(\"percentile\", s, \"--percentiles\", \"1,5,10,50,75,95,99\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "18",
    "metadata": {},
    "source": [
     "## 8. Результаты\n",
@@ -325,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "20",
    "metadata": {},
    "source": [
     "## 9. Предсказание биомассы (демо)\n",
@@ -355,15 +290,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
     "reg = results_dir / \"regression_csv\"\n",
     "\n",
     "def pick_csv(method, stage):\n",
-    "    \"\"\"CSV модели (train-регрессия, не _test) для метода и стадии.\n",
-    "    stage: 'Z31'/'Z65' -> файл с этим токеном; None -> combined (без токена).\"\"\"\n",
     "    cands = [p for p in (reg / method).glob(\"*.csv\")\n",
     "             if not p.stem.endswith(\"_test\")\n",
     "             and (f\"_{stage}_\" in f\"_{p.stem}_\" if stage\n",
@@ -371,7 +304,7 @@
     "    assert len(cands) == 1, f\"{method}/{stage}: ожидал 1 CSV, нашёл {len(cands)}: {cands}\"\n",
     "    return cands[0]\n",
     "\n",
-    "for stage in (None, \"Z31\", \"Z65\"):\n",
+    "for stage in STAGES:\n",
     "    print(\"\\n\" + \"=\" * 70)\n",
     "    print(f\"=== predict: stage={stage or 'combined'} ===\")\n",
     "    print(\"=\" * 70)\n",
@@ -386,7 +319,6 @@
     "        \"--count-csv\",  str(pick_csv(\"count\", stage)),\n",
     "    ]\n",
     "    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n",
-    "    # перехватываем вывод ребёнка и печатаем сами -> Jupyter его покажет\n",
     "    p = subprocess.run(cmd, cwd=REPO_DIR, capture_output=True, text=True)\n",
     "    print(p.stdout, end=\"\")\n",
     "    if p.stderr:\n",
@@ -397,7 +329,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "22",
    "metadata": {},
    "source": [
     "## 10. Сводные графики\n",
@@ -408,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,8 +356,7 @@
     "], cwd=REPO_DIR, check=True)\n",
     "\n",
     "# 2. Показать per-stage bar charts\n",
-    "stages = [\"combined\", \"Z31\", \"Z65\"]\n",
-    "for s in stages:\n",
+    "for s in STAGES:\n",
     "    png = summary_dir / f\"r2_stage_{s}.png\"\n",
     "    if png.exists():\n",
     "        print(f\"\\nStage: {s}\")\n",

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -338,6 +338,20 @@
     "archive = shutil.make_archive(\"/kaggle/working/tpcve_results\", \"zip\", results_dir)\n",
     "print(\"\\narchive:\", archive)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45edf9de",
+   "source": "## 9. Предсказание биомассы (демо)\n\nДля каждого варианта (`combined` / `Z31` / `Z65`) берёт train-регрессию (CSV без `_test`) соответствующей стадии по всем методам (`voxel`/`alpha`/`chm`/`percentile`/`count`), выбирает медианное по биомассе облако из `TEST_LIST`, прогоняет на нём все методы и печатает таблицу с абс./отн. ошибкой.\n\nЗапускай **после** того, как соответствующие batch+analyze отработали (combined и обе стадии).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ae23d948",
+   "source": "reg = results_dir / \"regression_csv\"\n\ndef pick_csv(method, stage):\n    \"\"\"CSV модели (train-регрессия, не _test) для метода и стадии.\n    stage: 'Z31'/'Z65' -> файл с этим токеном; None -> combined (без токена).\"\"\"\n    cands = [p for p in (reg / method).glob(\"*.csv\")\n             if not p.stem.endswith(\"_test\")\n             and (f\"_{stage}_\" in f\"_{p.stem}_\" if stage\n                  else (\"_Z31_\" not in p.stem and \"_Z65_\" not in p.stem))]\n    assert len(cands) == 1, f\"{method}/{stage}: ожидал 1 CSV, нашёл {len(cands)}: {cands}\"\n    return cands[0]\n\nfor stage in (None, \"Z31\", \"Z65\"):\n    print(\"\\n\" + \"=\" * 70)\n    print(f\"=== predict: stage={stage or 'combined'} ===\")\n    print(\"=\" * 70)\n    cmd = [\n        sys.executable, \"scripts/predict_biomass.py\",\n        \"--list\", str(TEST_LIST),\n        \"--base-dir\", str(DATA),\n        \"--voxel-csv\",  str(pick_csv(\"voxel\", stage)),\n        \"--alpha-csv\",  str(pick_csv(\"alpha\", stage)),\n        \"--chm-csv\",    str(pick_csv(\"chm\", stage)),\n        \"--height-csv\", str(pick_csv(\"percentile\", stage)),\n        \"--count-csv\",  str(pick_csv(\"count\", stage)),\n    ]\n    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n    p = subprocess.run(cmd, cwd=REPO_DIR)\n    if p.returncode:\n        raise SystemExit(f\"predict (stage={stage}) завершился с кодом {p.returncode}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -37,7 +37,7 @@
     "REPO_DIR = \"/kaggle/working/tpcve\"\n",
     "\n",
     "if not os.path.isdir(os.path.join(REPO_DIR, \".git\")):\n",
-    "    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", REPO_URL, REPO_DIR], check=True)\n",
+    "    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\", \"--branch\", \"kaggle-notebook\", REPO_URL, REPO_DIR], check=True)\n",
     "else:\n",
     "    print(\"repo already cloned\")\n",
     "\n",
@@ -122,6 +122,7 @@
     "        \"--list\", str(TRAIN_LIST),\n",
     "        \"--list-test\", str(TEST_LIST),\n",
     "        \"--base-dir\", str(DATA),\n",
+    "        \"--workers\", 4,\n",
     "        *method_flags,\n",
     "    ]\n",
     "    if stage is not None:\n",
@@ -229,7 +230,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env = {**os.environ, \"TQDM_MININTERVAL\": \"30\"}"
+    "#env = {**os.environ, \"TQDM_MININTERVAL\": \"30\"}"
    ]
   },
   {
@@ -243,8 +244,8 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",\n",
-    "          env=env)"
+    "          \"--no-inner-progress\",)\n",
+    "        #   env=env)"
    ]
   },
   {
@@ -258,8 +259,8 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",\n",
-    "          env=env)"
+    "          \"--no-inner-progress\",)\n",
+    "        #   env=env)"
    ]
   },
   {
@@ -273,8 +274,8 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
-    "          \"--no-inner-progress\",\n",
-    "          env=env)"
+    "          \"--no-inner-progress\",)\n",
+    "        #   env=env)"
    ]
   },
   {
@@ -341,17 +342,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45edf9de",
-   "source": "## 9. Предсказание биомассы (демо)\n\nДля каждого варианта (`combined` / `Z31` / `Z65`) берёт train-регрессию (CSV без `_test`) соответствующей стадии по всем методам (`voxel`/`alpha`/`chm`/`percentile`/`count`), выбирает медианное по биомассе облако из `TEST_LIST`, прогоняет на нём все методы и печатает таблицу с абс./отн. ошибкой.\n\nЗапускай **после** того, как соответствующие batch+analyze отработали (combined и обе стадии).",
-   "metadata": {}
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "## 9. Предсказание биомассы (демо)\n",
+    "\n",
+    "Для каждого варианта (`combined` / `Z31` / `Z65`) берёт train-регрессию (CSV без `_test`) соответствующей стадии по всем методам (`voxel`/`alpha`/`chm`/`percentile`/`count`), выбирает медианное по биомассе облако из `TEST_LIST`, прогоняет на нём все методы и печатает таблицу с абс./отн. ошибкой.\n",
+    "\n",
+    "Запускай **после** того, как соответствующие batch+analyze отработали (combined и обе стадии)."
+   ]
   },
   {
    "cell_type": "code",
-   "id": "ae23d948",
-   "source": "reg = results_dir / \"regression_csv\"\n\ndef pick_csv(method, stage):\n    \"\"\"CSV модели (train-регрессия, не _test) для метода и стадии.\n    stage: 'Z31'/'Z65' -> файл с этим токеном; None -> combined (без токена).\"\"\"\n    cands = [p for p in (reg / method).glob(\"*.csv\")\n             if not p.stem.endswith(\"_test\")\n             and (f\"_{stage}_\" in f\"_{p.stem}_\" if stage\n                  else (\"_Z31_\" not in p.stem and \"_Z65_\" not in p.stem))]\n    assert len(cands) == 1, f\"{method}/{stage}: ожидал 1 CSV, нашёл {len(cands)}: {cands}\"\n    return cands[0]\n\nfor stage in (None, \"Z31\", \"Z65\"):\n    print(\"\\n\" + \"=\" * 70)\n    print(f\"=== predict: stage={stage or 'combined'} ===\")\n    print(\"=\" * 70)\n    cmd = [\n        sys.executable, \"scripts/predict_biomass.py\",\n        \"--list\", str(TEST_LIST),\n        \"--base-dir\", str(DATA),\n        \"--voxel-csv\",  str(pick_csv(\"voxel\", stage)),\n        \"--alpha-csv\",  str(pick_csv(\"alpha\", stage)),\n        \"--chm-csv\",    str(pick_csv(\"chm\", stage)),\n        \"--height-csv\", str(pick_csv(\"percentile\", stage)),\n        \"--count-csv\",  str(pick_csv(\"count\", stage)),\n    ]\n    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n    p = subprocess.run(cmd, cwd=REPO_DIR)\n    if p.returncode:\n        raise SystemExit(f\"predict (stage={stage}) завершился с кодом {p.returncode}\")",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reg = results_dir / \"regression_csv\"\n",
+    "\n",
+    "def pick_csv(method, stage):\n",
+    "    \"\"\"CSV модели (train-регрессия, не _test) для метода и стадии.\n",
+    "    stage: 'Z31'/'Z65' -> файл с этим токеном; None -> combined (без токена).\"\"\"\n",
+    "    cands = [p for p in (reg / method).glob(\"*.csv\")\n",
+    "             if not p.stem.endswith(\"_test\")\n",
+    "             and (f\"_{stage}_\" in f\"_{p.stem}_\" if stage\n",
+    "                  else (\"_Z31_\" not in p.stem and \"_Z65_\" not in p.stem))]\n",
+    "    assert len(cands) == 1, f\"{method}/{stage}: ожидал 1 CSV, нашёл {len(cands)}: {cands}\"\n",
+    "    return cands[0]\n",
+    "\n",
+    "for stage in (None, \"Z31\", \"Z65\"):\n",
+    "    print(\"\\n\" + \"=\" * 70)\n",
+    "    print(f\"=== predict: stage={stage or 'combined'} ===\")\n",
+    "    print(\"=\" * 70)\n",
+    "    cmd = [\n",
+    "        sys.executable, \"scripts/predict_biomass.py\",\n",
+    "        \"--list\", str(TEST_LIST),\n",
+    "        \"--base-dir\", str(DATA),\n",
+    "        \"--voxel-csv\",  str(pick_csv(\"voxel\", stage)),\n",
+    "        \"--alpha-csv\",  str(pick_csv(\"alpha\", stage)),\n",
+    "        \"--chm-csv\",    str(pick_csv(\"chm\", stage)),\n",
+    "        \"--height-csv\", str(pick_csv(\"percentile\", stage)),\n",
+    "        \"--count-csv\",  str(pick_csv(\"count\", stage)),\n",
+    "    ]\n",
+    "    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n",
+    "    # перехватываем вывод ребёнка и печатаем сами -> Jupyter его покажет\n",
+    "    p = subprocess.run(cmd, cwd=REPO_DIR, capture_output=True, text=True)\n",
+    "    print(p.stdout, end=\"\")\n",
+    "    if p.stderr:\n",
+    "        print(p.stderr, end=\"\")\n",
+    "    if p.returncode:\n",
+    "        raise SystemExit(f\"predict (stage={stage}) завершился с кодом {p.returncode}\")"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# tpcve — оценка биомассы пшеницы (Kaggle)\n",
     "\n",
-    "Запуск трёх методов (`voxel`, `chm`, `alpha`) по dataset-спискам, **раздельно по стадиям роста** `--stage Z31` (дата 0828) и `--stage Z65` (дата 1002).\n",
+    "Запуск трёх методов (`voxel`, `chm`, `alpha`) по dataset-спискам, вместе и раздельно по стадиям роста `--stage Z31` (дата 0828) и `--stage Z65` (дата 1002).\n",
     "\n",
     "Каждый запуск: batch (признак по облакам) → автоматический analyze (регрессия `biomass ~ признак`, train+test).\n",
     "\n",
@@ -114,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_batch(method, stage, *method_flags, **kwargs):\n",
+    "def run_batch(method, stage=None, *method_flags, **kwargs):\n",
     "    \"\"\"Запустить batch.py для одного метода/стадии (train+test, analyze в цепочке).\"\"\"\n",
     "    cmd = [\n",
     "        sys.executable, \"batch.py\",\n",
@@ -122,9 +122,10 @@
     "        \"--list\", str(TRAIN_LIST),\n",
     "        \"--list-test\", str(TEST_LIST),\n",
     "        \"--base-dir\", str(DATA),\n",
-    "        \"--stage\", stage,\n",
     "        *method_flags,\n",
     "    ]\n",
+    "    if stage is not None:\n",
+    "        cmd.extend([\"--stage\", stage])\n",
     "    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n",
     "    p = subprocess.run(cmd, cwd=REPO_DIR, **kwargs)\n",
     "    if p.returncode:\n",
@@ -145,6 +146,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_batch(\"voxel\", \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac1fc150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +186,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_batch(\"chm\", \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f755fc31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,6 +239,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "run_batch(\"alpha\",\n",
+    "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
+    "          \"--alphas\", \"20,30,40\",\n",
+    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          env=env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7868d967",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "run_batch(\"alpha\", \"Z31\",\n",
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
@@ -246,7 +281,7 @@
    "source": [
     "## 7. Бейзлайны\n",
     "\n",
-    "`count` — число точек растительности → биомасса (простейший baseline). `percentile` — один скаляр (перцентиль высоты) → биомасса. Тоже раздельно по стадиям."
+    "`count` — число точек растительности → биомасса (простейший baseline). `percentile` — один скаляр (перцентиль высоты) → биомасса."
    ]
   },
   {
@@ -256,6 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "run_batch(\"count\")\n",
     "run_batch(\"count\", \"Z31\")\n",
     "run_batch(\"count\", \"Z65\")"
    ]
@@ -267,6 +303,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "run_batch(\"percentile\", \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
     "run_batch(\"percentile\", \"Z31\", \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
     "run_batch(\"percentile\", \"Z65\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
    ]

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac1fc150",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 5. CHM (объём по сетке высот)\n",
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f755fc31",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "source": [
     "## 6. Послойная альфа-форма\n",
@@ -225,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,13 +243,14 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          \"--no-inner-progress\",\n",
     "          env=env)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7868d967",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,13 +258,14 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          \"--no-inner-progress\",\n",
     "          env=env)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,12 +273,13 @@
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          \"--no-inner-progress\",\n",
     "          env=env)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "21",
    "metadata": {},
    "source": [
     "## 7. Бейзлайны\n",
@@ -287,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +313,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "24",
    "metadata": {},
    "source": [
     "## 8. Результаты\n",
@@ -321,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
     "# tpcve — оценка биомассы пшеницы (Kaggle)\n",
@@ -17,6 +18,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1",
    "metadata": {},
    "source": [
     "## 1. Клонирование кода"
@@ -25,6 +27,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3",
    "metadata": {},
    "source": [
     "## 2. Установка зависимостей\n",
@@ -54,15 +58,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"-e\", \".\"], check=True)\n",
+    "subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", \"uv\"], check=True)\n",
+    "subprocess.run([\"uv\", \"pip\", \"install\", \"--system\", \"-q\", \"-e\", \".\"], check=True)\n",
     "print(\"deps installed\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 3. Пути к данным + проверка\n",
@@ -73,15 +80,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "from tpcve.core.io import parse_list_line\n",
     "\n",
-    "DATA = Path(\"/kaggle/input/datasets/kobanur/wheat-biomass-and-lidar-dataset-yanco-2019/data\")\n",
-    "TRAIN_LIST = DATA / \"train_list.txt\"\n",
-    "TEST_LIST  = DATA / \"test_list.txt\"\n",
+    "DATA = Path(\"/kaggle/input/datasets/kobanur/wheat-biomass-and-lidar-dataset-yanco-2019/data/Yanco_TC_2019_HI-pcd\")\n",
+    "TRAIN_LIST = DATA / \"..\" / \"train_list.txt\"\n",
+    "TEST_LIST  = DATA / \"..\" / \"test_list.txt\"\n",
     "\n",
     "for p in (TRAIN_LIST, TEST_LIST):\n",
     "    assert p.exists(), f\"нет файла: {p}\"\n",
@@ -102,10 +110,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_batch(method, stage, *method_flags):\n",
+    "def run_batch(method, stage, *method_flags, **kwargs):\n",
     "    \"\"\"Запустить batch.py для одного метода/стадии (train+test, analyze в цепочке).\"\"\"\n",
     "    cmd = [\n",
     "        sys.executable, \"batch.py\",\n",
@@ -117,13 +126,14 @@
     "        *method_flags,\n",
     "    ]\n",
     "    print(\"\\n$ \" + \" \".join(cmd) + \"\\n\")\n",
-    "    p = subprocess.run(cmd, cwd=REPO_DIR)\n",
+    "    p = subprocess.run(cmd, cwd=REPO_DIR, **kwargs)\n",
     "    if p.returncode:\n",
     "        raise SystemExit(f\"batch завершился с кодом {p.returncode}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "8",
    "metadata": {},
    "source": [
     "## 4. Воксельный метод\n",
@@ -134,6 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,6 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,6 +163,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 5. CHM (объём по сетке высот)\n",
@@ -161,6 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,6 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,6 +193,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "14",
    "metadata": {},
    "source": [
     "## 6. Послойная альфа-форма\n",
@@ -188,30 +204,44 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = {**os.environ, \"TQDM_MININTERVAL\": \"30\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
     "run_batch(\"alpha\", \"Z31\",\n",
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
-    "          \"--layer-dz\", \"10,20,30,40,50,60\")"
+    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          env=env)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
     "run_batch(\"alpha\", \"Z65\",\n",
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
-    "          \"--layer-dz\", \"10,20,30,40,50,60\")"
+    "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
+    "          env=env)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2366c6e8",
+   "id": "18",
    "metadata": {},
    "source": [
     "## 7. Бейзлайны\n",
@@ -222,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddd2d359",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1a01bb1",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "829909dc",
+   "id": "21",
    "metadata": {},
    "source": [
     "## 8. Результаты\n",
@@ -254,6 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -122,7 +122,7 @@
     "        \"--list\", str(TRAIN_LIST),\n",
     "        \"--list-test\", str(TEST_LIST),\n",
     "        \"--base-dir\", str(DATA),\n",
-    "        \"--workers\", 4,\n",
+    "        \"--workers\", \"4\",\n",
     "        *method_flags,\n",
     "    ]\n",
     "    if stage is not None:\n",
@@ -394,16 +394,61 @@
     "    if p.returncode:\n",
     "        raise SystemExit(f\"predict (stage={stage}) завершился с кодом {p.returncode}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28",
+   "metadata": {},
+   "source": [
+    "## 10. Сводные графики\n",
+    "\n",
+    "Горизонтальные bar chart: лучший R² + bootstrap CI для каждого метода, раздельно по стадиям."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image, display\n",
+    "\n",
+    "summary_dir = results_dir / \"figures\" / \"summary\"\n",
+    "\n",
+    "# 1. Сгенерировать сводные графики\n",
+    "subprocess.run([\n",
+    "    sys.executable, \"scripts/plot_summary.py\",\n",
+    "    \"--results-dir\", str(results_dir),\n",
+    "    \"--output-dir\", str(summary_dir),\n",
+    "], cwd=REPO_DIR, check=True)\n",
+    "\n",
+    "# 2. Показать per-stage bar charts\n",
+    "stages = [\"combined\", \"Z31\", \"Z65\"]\n",
+    "for s in stages:\n",
+    "    png = summary_dir / f\"r2_stage_{s}.png\"\n",
+    "    if png.exists():\n",
+    "        print(f\"\\nStage: {s}\")\n",
+    "        display(Image(filename=str(png)))\n",
+    "\n",
+    "# 3. Показать лучшие регрессионные графики\n",
+    "best_dir = summary_dir / \"best_fits\"\n",
+    "if best_dir.is_dir():\n",
+    "    for png in sorted(best_dir.glob(\"*.png\")):\n",
+    "        print(f\"\\n{png.stem}\")\n",
+    "        display(Image(filename=str(png)))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "name": "python",
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/kaggle_run.ipynb
+++ b/notebooks/kaggle_run.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"voxel\", \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
+    "run_batch(\"voxel\", None, \"--voxel-sizes\", \"10,15,20,25,30,35,40,45\")"
    ]
   },
   {
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"chm\", \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
+    "run_batch(\"chm\", None, \"--cell-sizes\", \"10,15,20,25\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
    ]
   },
   {
@@ -239,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"alpha\",\n",
+    "run_batch(\"alpha\", None,\n",
     "          \"--voxel-sizes\", \"10,20,30,40,50\",\n",
     "          \"--alphas\", \"20,30,40\",\n",
     "          \"--layer-dz\", \"10,20,30,40,50,60\",\n",
@@ -294,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"count\")\n",
+    "run_batch(\"count\", None)\n",
     "run_batch(\"count\", \"Z31\")\n",
     "run_batch(\"count\", \"Z65\")"
    ]
@@ -306,7 +306,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_batch(\"percentile\", \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
+    "run_batch(\"percentile\", None, \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
     "run_batch(\"percentile\", \"Z31\", \"--percentiles\", \"1,5,10,50,75,95,99\")\n",
     "run_batch(\"percentile\", \"Z65\", \"--percentiles\", \"1,5,10,50,75,95,99\")"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["tpcve", "tools"]
+
+[dependency-groups]
+dev = [
+    "nbstripout>=0.9.1",
+]

--- a/scripts/plot_summary.py
+++ b/scripts/plot_summary.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+METHODS = ["voxel", "alpha", "chm", "percentile", "count"]
+VOLUME_METHODS = {"voxel", "alpha", "chm"}
+
+COLOR_VOLUME = "#1f77b4"
+COLOR_OTHER = "#999999"
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Generate summary plots from regression CSVs")
+    p.add_argument("--results-dir", default="results",
+                    help="Root results directory (default: results)")
+    p.add_argument("--stages", default="combined,Z31,Z65",
+                    help="Comma-separated stage list (default: combined,Z31,Z65)")
+    p.add_argument("--output-dir", default="results/figures/summary",
+                    help="Output directory for plots (default: results/figures/summary)")
+    return p.parse_args(argv)
+
+
+def _pick_csv(method_dir: Path, stage: str, test: bool) -> Path | None:
+    cands = []
+    for p in method_dir.glob("*.csv"):
+        stem = p.stem
+        is_test = stem.endswith("_test")
+        if test != is_test:
+            continue
+        clean = stem[:-5] if is_test else stem
+        if stage == "combined":
+            if "_Z31_" in clean or "_Z65_" in clean:
+                continue
+        else:
+            if f"_{stage.upper()}_" not in f"_{clean}_":
+                continue
+        cands.append(p)
+    if len(cands) == 1:
+        return cands[0]
+    if len(cands) > 1:
+        return sorted(cands, key=lambda p: p.stat().st_mtime, reverse=True)[0]
+    return None
+
+
+def _load_best(method_dir: Path, stage: str) -> dict | None:
+    if not method_dir.is_dir():
+        return None
+    train_csv = _pick_csv(method_dir, stage, test=False)
+    if train_csv is None:
+        return None
+    df = pd.read_csv(train_csv)
+    if df.empty:
+        return None
+
+    rank_cols = [c for c in df.columns if c.endswith("_r2") and not c.startswith("best")]
+    if rank_cols:
+        df = df.assign(_max_r2=df[rank_cols].max(axis=1))
+        df = df.sort_values("_max_r2", ascending=False).drop(columns="_max_r2").reset_index(drop=True)
+
+    best_row = df.iloc[0]
+    method = method_dir.name
+    param_label = str(best_row.get("method", ""))
+    x_col = str(best_row.get("x_col", ""))
+    best_model = str(best_row.get("best_model", "linear"))
+    r2 = float(best_row.get(f"{best_model}_r2", float("nan")))
+    if not np.isfinite(r2):
+        return None
+
+    ci_lo, ci_hi = float("nan"), float("nan")
+    test_csv = _pick_csv(method_dir, stage, test=True)
+    if test_csv is None:
+        print(f"  [warn] {method}/{stage}: нет _test.csv — CI не будут отображены")
+    else:
+        tdf = pd.read_csv(test_csv)
+        if not tdf.empty and 'x_col' in tdf.columns:
+            match = tdf[tdf["x_col"] == x_col]
+            if not match.empty:
+                row = match.iloc[0]
+                ci_lo = float(row.get(f"{best_model}_test_r2_ci_lo", float("nan")))
+                ci_hi = float(row.get(f"{best_model}_test_r2_ci_hi", float("nan")))
+
+    return {
+        "method": method,
+        "param_label": param_label,
+        "r2": r2,
+        "ci_lo": ci_lo,
+        "ci_hi": ci_hi,
+        "x_col": x_col,
+    }
+
+
+def _plot_stage(data: list[dict], stage: str, out_dir: Path) -> None:
+    data = sorted(data, key=lambda d: -d["r2"])
+    methods_raw = [d["method"] for d in data]
+    r2_vals = [d["r2"] for d in data]
+    ci_lo = [d["ci_lo"] for d in data]
+    ci_hi = [d["ci_hi"] for d in data]
+    methods_label = []
+    for d in data:
+        label = d["param_label"]
+        if label:
+            label = label.replace("_layered", "").replace("layered_", "")
+            methods_label.append(f"{d['method']}\n{label}")
+        else:
+            methods_label.append(d["method"])
+
+    fig, ax = plt.subplots(figsize=(6, 1.8 + 0.35 * len(data)))
+    y_pos = range(len(data))
+
+    for i, (r2, y, method) in enumerate(zip(r2_vals, y_pos, methods_raw)):
+        c = COLOR_VOLUME if method in VOLUME_METHODS else COLOR_OTHER
+        lo, hi = ci_lo[i], ci_hi[i]
+        has_ci = np.isfinite(lo) and np.isfinite(hi) and lo < hi
+        if has_ci:
+            ax.plot([lo, hi], [y, y], color=c, lw=2, solid_capstyle="round")
+        ax.plot(r2, y, color=c, marker="o", markersize=9,
+                markeredgecolor="white", markeredgewidth=1.5, zorder=5)
+
+    ax.set_yticks(list(y_pos))
+    ax.set_yticklabels(methods_label, fontsize=10)
+    ax.set_xlabel("$R^2$ & 95% CI", fontsize=11)
+    ax.set_title(f"Stage: {stage}", fontsize=12, fontweight="bold")
+    ax.set_xlim(0, 1.05)
+    ax.set_ylim(-0.6, len(data) - 0.6)
+    ax.invert_yaxis()
+    ax.grid(axis="x", alpha=0.3)
+
+    for i, (r2, y) in enumerate(zip(r2_vals, y_pos)):
+        ax.text(r2, y - 0.18, f"{r2:.3f}", ha="center", va="bottom", fontsize=9)
+
+    from matplotlib.lines import Line2D
+    ax.legend(handles=[
+        Line2D([0], [0], color=COLOR_VOLUME, marker="o", markersize=7,
+               markeredgecolor="white", markeredgewidth=1.2, lw=2,
+               label="Volume methods"),
+        Line2D([0], [0], color=COLOR_OTHER, marker="o", markersize=7,
+               markeredgecolor="white", markeredgewidth=1.2, lw=2,
+               label="Baseline methods"),
+    ], fontsize=8, loc="upper left")
+
+    fig.tight_layout()
+    fname = f"r2_stage_{stage}.png"
+    fig.savefig(out_dir / fname, dpi=130)
+    plt.close(fig)
+
+
+def _copy_best_fits(csv_root: Path, best_dir: Path, stages: list[str]) -> None:
+    """Copy the best-fit regression PNG per method from regression_plots."""
+    plots_root = csv_root.parent / "regression_plots"
+    if not plots_root.is_dir():
+        return
+    best_dir.mkdir(parents=True, exist_ok=True)
+    for method_dir in csv_root.iterdir():
+        if not method_dir.is_dir():
+            continue
+        method = method_dir.name
+        for stage in stages:
+            info = _load_best(method_dir, stage)
+            if info is None or not info["x_col"]:
+                continue
+            png_name = f"{method}__{info['x_col']}.png".replace("/", "_")
+            src = plots_root / method / png_name
+            if src.exists():
+                dst = best_dir / f"{method}__{stage}__{info['x_col']}.png"
+                shutil.copy2(src, dst)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    results_dir = Path(args.results_dir)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    stages = [s.strip() for s in args.stages.split(",") if s.strip()]
+    csv_root = results_dir / "regression_csv"
+
+    for stage in stages:
+        stage_data = []
+        for method in METHODS:
+            row = _load_best(csv_root / method, stage)
+            if row is not None:
+                stage_data.append(row)
+        if not stage_data:
+            print(f"[{stage}] нет данных")
+            continue
+        _plot_stage(stage_data, stage, out_dir)
+        print(f"[{stage}] график сохранён")
+
+    _copy_best_fits(csv_root, out_dir / "best_fits", stages)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tpcve/core/io.py
+++ b/tpcve/core/io.py
@@ -65,6 +65,10 @@ def collect_inputs(cfg, *, list_file: str | None = None) -> list[InputItem]:
                 rel, labels = parse_list_line(line)
                 if stage is not None and stage_from_path(rel) != stage:
                     continue
+                # без явной стадии Z31+Z65 идут вместе -> для чистоты
+                # эксперимента биомассу Z65 делим на 2
+                if stage is None and stage_from_path(rel) == "Z65":
+                    labels["biomass"] = str(float(labels["biomass"]) / 2)
                 full = cfg.base_dir / rel.lstrip("/\\")
                 items.append(InputItem(rel, full, labels))
     elif cfg.input_dir and list_file is None:

--- a/tpcve/core/io.py
+++ b/tpcve/core/io.py
@@ -65,9 +65,8 @@ def collect_inputs(cfg, *, list_file: str | None = None) -> list[InputItem]:
                 rel, labels = parse_list_line(line)
                 if stage is not None and stage_from_path(rel) != stage:
                     continue
-                # без явной стадии Z31+Z65 идут вместе -> для чистоты
-                # эксперимента биомассу Z65 делим на 2
-                if stage is None and stage_from_path(rel) == "Z65":
+                # для чистоты эксперимента биомассу Z65 всегда делим на 2
+                if stage_from_path(rel) == "Z65":
                     labels["biomass"] = str(float(labels["biomass"]) / 2)
                 full = cfg.base_dir / rel.lstrip("/\\")
                 items.append(InputItem(rel, full, labels))

--- a/tpcve/methods/alpha.py
+++ b/tpcve/methods/alpha.py
@@ -63,6 +63,7 @@ class AlphaConfig:
     resume: bool
     limit: int | None
     stage: str | None = None
+    inner_progress: bool = True
     preprocess: PreprocessConfig = field(default_factory=PreprocessConfig)
 
 
@@ -82,6 +83,9 @@ def add_batch_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--workers", type=int,
                    default=max(1, (os.cpu_count() or 2) // 2))
+    p.add_argument("--no-inner-progress", action="store_true",
+                   help="Отключить вложенный tqdm-бар по α-shape задачам "
+                        "(полезно при не-TTY выводе, напр. на Kaggle)")
 
 
 def add_analyze_args(p: argparse.ArgumentParser) -> None:
@@ -261,6 +265,7 @@ def process_batch(cfg: AlphaConfig, *,
 
                 inner = tqdm(total=len(tasks), unit="task",
                              leave=False, dynamic_ncols=True,
+                             disable=not cfg.inner_progress,
                              desc=f"  α-shape ({item.rel_path[-25:]})")
                 if ex is None:
                     for task in tasks:
@@ -345,6 +350,7 @@ def run_batch(argv=None) -> Path:
         seed=a.seed, workers=a.workers,
         resume=a.resume, limit=a.limit,
         stage=a.stage,
+        inner_progress=not a.no_inner_progress,
         preprocess=core.preprocess_config_from_args(a),
     )
     process_batch(cfg, csv_path=output_csv, label="train")

--- a/tpcve/methods/alpha.py
+++ b/tpcve/methods/alpha.py
@@ -62,6 +62,7 @@ class AlphaConfig:
     workers: int
     resume: bool
     limit: int | None
+    stage: str | None = None
     preprocess: PreprocessConfig = field(default_factory=PreprocessConfig)
 
 
@@ -343,6 +344,7 @@ def run_batch(argv=None) -> Path:
         with_random=a.with_random,
         seed=a.seed, workers=a.workers,
         resume=a.resume, limit=a.limit,
+        stage=a.stage,
         preprocess=core.preprocess_config_from_args(a),
     )
     process_batch(cfg, csv_path=output_csv, label="train")

--- a/uv.lock
+++ b/uv.lock
@@ -885,6 +885,18 @@ wheels = [
 ]
 
 [[package]]
+name = "nbstripout"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nbformat" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6f/b52c4da26babeb521078c08c78c3187a59197098ffc7a70b0fe76851813a/nbstripout-0.9.1.tar.gz", hash = "sha256:313bbb4217c8e38998567e5d790b6bd6c3a17a8c39073b205b84dadfc5d756dc", size = 32356, upload-time = "2026-02-21T16:19:55.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/16/e777eadfa0c0305878c36fae1d5e6db474fbb15dae202b9ec378809dfb4d/nbstripout-0.9.1-py3-none-any.whl", hash = "sha256:ca027ee45742ee77e4f8e9080254f9a707f1161ba11367b82fdf4a29892c759e", size = 19136, upload-time = "2026-02-21T16:19:54.868Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1802,6 +1814,11 @@ dependencies = [
     { name = "scipy" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "nbstripout" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "alphashape", specifier = ">=1.3.1" },
@@ -1814,6 +1831,9 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.17.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "nbstripout", specifier = ">=0.9.1" }]
 
 [[package]]
 name = "tqdm"


### PR DESCRIPTION
- feat: add main.py for full pipeline and plot_summary.py
- chore: tune Kaggle notebook (uv, data path, alpha tqdm)
- fix: respect --stage in alpha batch
- feat: halve Z65 biomass when running without --stage
- feat: add combined (no-stage) runs to Kaggle notebook
- feat: add --no-inner-progress flag to alpha batch
- fix: pass explicit None stage in combined Kaggle runs
- feat: run biomass prediction per stage (combined/Z31/Z65) in notebook
- feat: always halve Z65 biomass
- feat(notebooks): pin clone branch, add workers, drop env, fix predict output
- chore: add nbstripout as dev dep, add summary plots to notebook
