### PR TITLE
predict binary

### DIFF
--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -25,16 +25,51 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Cache dataset
+        uses: actions/cache@v4
+        with:
+          path: datasets/yanco-2019-wheat-pcd/data
+          key: dataset-v1
+
+      - name: Cache uv venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+
+      - name: Cache results
+        id: cache-results
+        uses: actions/cache@v4
+        with:
+          path: results
+          key: ${{ runner.os }}-results-v1-${{ hashFiles('main.py', 'batch.py', 'analyze.py', 'tpcve/core/**/*.py', 'tpcve/methods/**/*.py') }}
 
       - name: Install uv
         run: pip install uv
 
       - name: Sync dependencies
         run: uv sync
+
+      - name: Run full pipeline
+        if: steps.cache-results.outputs.cache-hit != 'true'
+        run: uv run python main.py
+
+      - name: Generate predict.py from frozen models
+        run: uv run python tools/freeze_model.py
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: results-${{ matrix.artifact_name }}
+          path: results/
+          overwrite: true
 
       - name: Install UPX (Linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -113,10 +113,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist/predict${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          path: dist/predict${{ matrix.os == 'windows-2022' && '.exe' || '' }}
 
       - name: Upload to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/predict${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          files: dist/predict${{ matrix.os == 'windows-2022' && '.exe' || '' }}

--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -11,15 +11,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             artifact_name: predict-linux
             asset_name: predict-linux
-          - os: windows-latest
+          - os: windows-2022
             artifact_name: predict-windows.exe
             asset_name: predict-windows.exe
-          - os: macos-latest
-            artifact_name: predict-macos
-            asset_name: predict-macos
+          - os: macos-13
+            artifact_name: predict-macos-x64
+            asset_name: predict-macos-x64
+          - os: macos-14
+            artifact_name: predict-macos-arm64
+            asset_name: predict-macos-arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -43,6 +46,12 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+
+      - name: Cache uv packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-packages-${{ hashFiles('uv.lock') }}
 
       - name: Cache results
         id: cache-results

--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -1,0 +1,78 @@
+name: Build predict executables
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: predict-linux
+            asset_name: predict-linux
+          - os: windows-latest
+            artifact_name: predict-windows.exe
+            asset_name: predict-windows.exe
+          - os: macos-latest
+            artifact_name: predict-macos
+            asset_name: predict-macos
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Install UPX (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq upx-ucl
+
+      - name: Install UPX (macOS)
+        if: runner.os == 'macOS'
+        run: brew install upx
+
+      - name: Install UPX (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          curl -sL https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-win64.zip -o upx.zip
+          unzip -o upx.zip
+          echo "${{ github.workspace }}/upx-4.2.4-win64" >> $env:GITHUB_PATH
+
+      - name: Build executable
+        run: |
+          uv run pyinstaller \
+            --onefile \
+            --name predict \
+            --collect-all numpy \
+            --hidden-import dotenv \
+            --upx \
+            --strip \
+            --distpath dist \
+            --workpath build \
+            --specpath build \
+            predict.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/predict${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/predict${{ matrix.os == 'windows-latest' && '.exe' || '' }}

--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -119,7 +119,6 @@ jobs:
           uv run pyinstaller \
             --onefile \
             --name predict \
-            --collect-all numpy \
             --hidden-import dotenv \
             --upx \
             --strip \

--- a/.github/workflows/build-predict.yml
+++ b/.github/workflows/build-predict.yml
@@ -6,8 +6,62 @@ on:
       - "v*"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  pipeline:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache dataset
+        id: cache-dataset
+        uses: actions/cache@v4
+        with:
+          path: datasets/yanco-2019-wheat-pcd/data
+          key: dataset-v2-${{ hashFiles('datasets/yanco-2019-wheat-pcd/**') }}
+
+      - name: Cache results
+        id: cache-results
+        uses: actions/cache@v4
+        with:
+          path: results
+          key: results-v2-${{ hashFiles('main.py', 'batch.py', 'analyze.py', 'tpcve/core/**/*.py', 'tpcve/methods/**/*.py') }}
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Run full pipeline
+        if: steps.cache-results.outputs.cache-hit != 'true'
+        run: uv run python main.py
+
+      - name: Generate predict.py from frozen models
+        run: uv run python tools/freeze_model.py
+
+      - name: Upload pipeline results
+        uses: actions/upload-artifact@v4
+        with:
+          name: pipeline-results
+          path: |
+            results/
+            predict.py
+          overwrite: true
+
   build:
+    needs: [pipeline]
     strategy:
       matrix:
         include:
@@ -35,50 +89,15 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Cache dataset
-        uses: actions/cache@v4
+      - name: Download pipeline results
+        uses: actions/download-artifact@v4
         with:
-          path: datasets/yanco-2019-wheat-pcd/data
-          key: dataset-v1
+          name: pipeline-results
 
-      - name: Cache uv venv
-        uses: actions/cache@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          path: .venv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
-
-      - name: Cache uv packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-packages-${{ hashFiles('uv.lock') }}
-
-      - name: Cache results
-        id: cache-results
-        uses: actions/cache@v4
-        with:
-          path: results
-          key: ${{ runner.os }}-results-v1-${{ hashFiles('main.py', 'batch.py', 'analyze.py', 'tpcve/core/**/*.py', 'tpcve/methods/**/*.py') }}
-
-      - name: Install uv
-        run: pip install uv
-
-      - name: Sync dependencies
-        run: uv sync
-
-      - name: Run full pipeline
-        if: steps.cache-results.outputs.cache-hit != 'true'
-        run: uv run python main.py
-
-      - name: Generate predict.py from frozen models
-        run: uv run python tools/freeze_model.py
-
-      - name: Upload results
-        uses: actions/upload-artifact@v4
-        with:
-          name: results-${{ matrix.artifact_name }}
-          path: results/
-          overwrite: true
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install UPX (Linux)
         if: runner.os == 'Linux'
@@ -108,6 +127,10 @@ jobs:
             --workpath build \
             --specpath build \
             predict.py
+
+      - name: Smoke test (--help)
+        run: |
+          dist/predict${{ matrix.os == 'windows-2022' && '.exe' || '' }} --help
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ wheels/
 *.log
 results*/
 .env
+predict.py

--- a/experiments/downsample_alpha_compare.py
+++ b/experiments/downsample_alpha_compare.py
@@ -18,12 +18,11 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
 
 import numpy as np
-import open3d as o3d
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from tqdm import tqdm
 
-from tpcve.cloud.geometry import _compute_one, random_downsample, sor, voxel_downsample
+from tpcve.cloud.geometry import _compute_one, random_downsample, sor_np, voxel_downsample_np
 from tpcve.cloud.generate_cloud import load_real_cloud
 from tools.autoname import build_name, default_path
 
@@ -172,10 +171,10 @@ def main() -> int:
 
     sizes_mm = list(args.voxel_sizes_mm)
     if args.auto:
-        pcd = o3d.geometry.PointCloud()
-        pcd.points = o3d.utility.Vector3dVector(pts)
-        nn = np.asarray(pcd.compute_nearest_neighbor_distance())
-        mean_nn_mm = float(nn.mean()) * 1000
+        from scipy.spatial import KDTree
+        tree = KDTree(pts)
+        nn_dist, _ = tree.query(pts, k=2)
+        mean_nn_mm = float(nn_dist[:, 1].mean()) * 1000
         print(f"  --auto: среднее nn-расстояние = {mean_nn_mm:.3f} мм")
         sizes_mm.append(mean_nn_mm)
 
@@ -203,14 +202,14 @@ def main() -> int:
     summary = []  # (size_mm, alpha, v_vol, r_vol)
     for size_mm in sizes_mm:
         size_m = size_mm / 1000.0
-        v_pts = voxel_downsample(pts, size_m)
+        v_pts = voxel_downsample_np(pts, size_m)
         r_pts = random_downsample(pts, len(v_pts), args.seed)
         msg = (f"  voxel={size_mm:g} мм → {len(v_pts):,} | "
                f"random({args.seed}) → {len(r_pts):,}")
         if args.sor:
             n_v0, n_r0 = len(v_pts), len(r_pts)
-            v_pts = sor(v_pts, args.sor_neighbors, args.sor_std_ratio)
-            r_pts = sor(r_pts, args.sor_neighbors, args.sor_std_ratio)
+            v_pts = sor_np(v_pts, args.sor_neighbors, args.sor_std_ratio)
+            r_pts = sor_np(r_pts, args.sor_neighbors, args.sor_std_ratio)
             msg += (f" | SOR(k={args.sor_neighbors},σ={args.sor_std_ratio}): "
                     f"voxel {n_v0:,}→{len(v_pts):,}, "
                     f"random {n_r0:,}→{len(r_pts):,}")

--- a/experiments/downsample_compare.py
+++ b/experiments/downsample_compare.py
@@ -14,12 +14,11 @@ import argparse
 from pathlib import Path
 
 import numpy as np
-import open3d as o3d
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 
 from tpcve.cloud.generate_cloud import load_real_cloud
-from tpcve.cloud.geometry import random_downsample, sor, voxel_downsample
+from tpcve.cloud.geometry import random_downsample, sor_np, voxel_downsample_np
 from tools.autoname import build_name, default_path
 
 
@@ -86,10 +85,10 @@ def main() -> int:
 
     sizes_mm = list(args.voxel_sizes_mm)
     if args.auto:
-        pcd = o3d.geometry.PointCloud()
-        pcd.points = o3d.utility.Vector3dVector(pts)
-        nn = np.asarray(pcd.compute_nearest_neighbor_distance())
-        mean_nn_mm = float(nn.mean()) * 1000
+        from scipy.spatial import KDTree
+        tree = KDTree(pts)
+        nn_dist, _ = tree.query(pts, k=2)
+        mean_nn_mm = float(nn_dist[:, 1].mean()) * 1000
         print(f"  --auto: среднее nn-расстояние = {mean_nn_mm:.3f} мм")
         sizes_mm.append(mean_nn_mm)
 
@@ -114,14 +113,14 @@ def main() -> int:
     sor_on = args.sor
     for size_mm in sizes_mm:
         size_m = size_mm / 1000.0
-        v_pts = voxel_downsample(pts, size_m)
+        v_pts = voxel_downsample_np(pts, size_m)
         r_pts = random_downsample(pts, len(v_pts), args.seed)
         msg = (f"  voxel={size_mm:g} мм → {len(v_pts):,} точек "
                f"| random({args.seed}) → {len(r_pts):,}")
         if sor_on:
             n_v_before, n_r_before = len(v_pts), len(r_pts)
-            v_pts = sor(v_pts, args.sor_neighbors, args.sor_std_ratio)
-            r_pts = sor(r_pts, args.sor_neighbors, args.sor_std_ratio)
+            v_pts = sor_np(v_pts, args.sor_neighbors, args.sor_std_ratio)
+            r_pts = sor_np(r_pts, args.sor_neighbors, args.sor_std_ratio)
             msg += (f" | SOR(k={args.sor_neighbors},σ={args.sor_std_ratio}): "
                     f"voxel {n_v_before:,}→{len(v_pts):,}, "
                     f"random {n_r_before:,}→{len(r_pts):,}")

--- a/main.py
+++ b/main.py
@@ -28,6 +28,8 @@ def _parse_args(argv=None) -> argparse.Namespace:
                    help="Стадии через запятую: combined, Z31, Z65 — каждая запускается отдельно (по умолчанию combined,Z31,Z65)")
     p.add_argument("--workers", type=int, default=2,
                    help="Число воркеров для batch.py (default: 2)")
+    p.add_argument("--preprocess-cache", default="results/.preprocess_cache",
+                   help="Директория кеша препроцессинга (default: results/.preprocess_cache)")
     return p.parse_args(argv)
 
 
@@ -52,7 +54,7 @@ def _setup() -> tuple[Path, Path, Path, Path]:
     return REPO_DIR, DATA, TRAIN_LIST, TEST_LIST
 
 
-def _run_batch(method, stage, train_list, test_list, data, repo_dir, workers, *method_flags, **kwargs):
+def _run_batch(method, stage, train_list, test_list, data, repo_dir, workers, preprocess_cache, *method_flags, **kwargs):
     """Запустить batch.py для одного метода/стадии (train+test, analyze в цепочке)."""
     cmd = [
         sys.executable, "batch.py",
@@ -61,6 +63,7 @@ def _run_batch(method, stage, train_list, test_list, data, repo_dir, workers, *m
         "--list-test", str(test_list),
         "--base-dir", str(data),
         "--workers", str(workers),
+        "--preprocess-cache", str(preprocess_cache),
         *method_flags,
     ]
     if stage is not None:
@@ -83,7 +86,7 @@ def main(argv=None) -> int:
     results_dir = repo_dir / "results"
 
     def r(m, s, *f):
-        _run_batch(m, s, train_list, test_list, data, repo_dir, args.workers, *f)
+        _run_batch(m, s, train_list, test_list, data, repo_dir, args.workers, args.preprocess_cache, *f)
 
     # 4. Воксельный метод
     voxel_cfg = "--voxel-sizes", "10,15,20,25,30,35,40,45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "numpy>=2.4.4",
     "open3d>=0.19.0",
     "optuna>=4.8.0",
+    "pytest>=9.1.1",
     "python-dotenv>=1.2.2",
     "rosbags>=0.11.0",
     "scikit-learn>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ dependencies = [
     "alphashape>=1.3.1",
     "matplotlib>=3.10.8",
     "numpy>=2.4.4",
-    "open3d>=0.19.0",
-    "optuna>=4.8.0",
-    "pytest>=9.1.1",
     "python-dotenv>=1.2.2",
     "rosbags>=0.11.0",
     "scikit-learn>=1.8.0",
@@ -30,4 +27,11 @@ packages = ["tpcve", "tools"]
 dev = [
     "nbstripout>=0.9.1",
     "pyinstaller>=6.21.0",
+    "pytest>=9.1.1",
+]
+
+extra = [
+    "laspy>=2.5.4",
+    "open3d>=0.19.0",
+    "optuna>=4.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,5 @@ packages = ["tpcve", "tools"]
 [dependency-groups]
 dev = [
     "nbstripout>=0.9.1",
+    "pyinstaller>=6.21.0",
 ]

--- a/tests/test_readers.py
+++ b/tests/test_readers.py
@@ -1,0 +1,78 @@
+import numpy as np
+from pathlib import Path
+from tpcve.cloud.generate_cloud import _read_pcd_np, _read_ply_np
+
+def test_read_pcd_ascii_crlf():
+    """PCD with \\r\\n line endings should parse correctly."""
+    content = (
+        "VERSION .7\n"
+        "FIELDS x y z\n"
+        "SIZE 4 4 4\n"
+        "TYPE F F F\n"
+        "COUNT 1 1 1\n"
+        "WIDTH 3\n"
+        "HEIGHT 1\n"
+        "VIEWPOINT 0 0 0 1 0 0 0\n"
+        "DATA ascii\n"
+        "1.0 2.0 3.0\r\n"
+        "4.0 5.0 6.0\r\n"
+        "7.0 8.0 9.0\r\n"
+    ).encode('ascii')
+    tmp = Path("/tmp/test_crlf.pcd")
+    tmp.write_bytes(content)
+    try:
+        pts = _read_pcd_np(str(tmp))
+        assert pts.shape == (3, 3), f"Expected (3,3), got {pts.shape}"
+        np.testing.assert_array_almost_equal(pts, [[1,2,3],[4,5,6],[7,8,9]])
+    finally:
+        tmp.unlink()
+
+
+def test_read_ply_binary_raises_friendly():
+    """Binary PLY should raise ValueError, not UnicodeDecodeError."""
+    content = (
+        b"ply\n"
+        b"format binary_little_endian 1.0\n"
+        b"element vertex 2\n"
+        b"property float x\n"
+        b"property float y\n"
+        b"property float z\n"
+        b"end_header\n"
+        + np.array([[1,2,3],[4,5,6]], dtype=np.float32).tobytes()
+    )
+    tmp = "/tmp/test_binary.ply"
+    with open(tmp, "wb") as f:
+        f.write(content)
+    try:
+        _read_ply_np(tmp)
+        assert False, "Expected ValueError"
+    except UnicodeDecodeError:
+        assert False, "Got UnicodeDecodeError instead of ValueError"
+    except ValueError as e:
+        assert "ASCII" in str(e) or "ascii" in str(e)
+    finally:
+        import os; os.unlink(tmp)
+
+
+def test_read_ply_format_with_extra_spaces():
+    """PLY with multiple spaces in format line should still work."""
+    content = (
+        "ply\n"
+        "format  ascii  1.0\n"
+        "element vertex 2\n"
+        "property float x\n"
+        "property float y\n"
+        "property float z\n"
+        "end_header\n"
+        "1.0 2.0 3.0\n"
+        "4.0 5.0 6.0\n"
+    ).encode('ascii')
+    tmp = "/tmp/test_spaces.ply"
+    with open(tmp, "wb") as f:
+        f.write(content)
+    try:
+        pts = _read_ply_np(tmp)
+        assert pts.shape == (2, 3)
+        np.testing.assert_array_almost_equal(pts, [[1,2,3],[4,5,6]])
+    finally:
+        import os; os.unlink(tmp)

--- a/tools/freeze_model.py
+++ b/tools/freeze_model.py
@@ -24,8 +24,6 @@ def extract_best_row(csv_path: str) -> dict | None:
     if df.empty:
         return None
     row = df.iloc[0]
-    best_model = str(row["best_model"])
-    r2 = float(row.get(f"{best_model}_r2", 0))
 
     if "voxel_mm" in df.columns and "alpha" in df.columns:
         kind = "alpha"

--- a/tools/freeze_model.py
+++ b/tools/freeze_model.py
@@ -146,11 +146,10 @@ import sys
 from pathlib import Path
 
 import numpy as np
-import open3d as o3d
 
 from tpcve.cloud.cloud_pipeline import PreprocessConfig, preprocess_cloud
 from tpcve.cloud.volume_methods import voxel_volume
-from tpcve.cloud.geometry import alpha_layered
+from tpcve.cloud.geometry import alpha_layered, voxel_downsample_np
 from tpcve.methods.chm import chm_volume
 from tpcve.core.io import parse_list_line, stage_from_path
 
@@ -180,10 +179,7 @@ def _compute_feature(m: dict, veg: np.ndarray, pre) -> float:
         pts = veg
         vm = p.get("voxel_mm", 0)
         if vm > 0 and len(pts):
-            pcd = o3d.geometry.PointCloud()
-            pcd.points = o3d.utility.Vector3dVector(pts)
-            pcd = pcd.voxel_down_sample(voxel_size=vm / 1000.0)
-            pts = np.asarray(pcd.points)
+            pts = voxel_downsample_np(pts, vm / 1000.0)
         _, vol = alpha_layered(pts, p["alpha"], p["dz_m"], with_rings=False)
         return float(vol)
     if kind == "chm":

--- a/tools/freeze_model.py
+++ b/tools/freeze_model.py
@@ -1,0 +1,610 @@
+"""Вморозить регрессионную модель в standalone predict.py.
+
+Читает regression CSV (результат analyze.py), извлекает лучшие модели
+и создаёт файл predict.py с вшитыми коэффициентами.
+
+Пример:
+    python tools/freeze_model.py --stage Z31 --output predict.py
+    python tools/freeze_model.py --voxel-csv results/...csv --output predict.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def extract_best_row(csv_path: str) -> dict | None:
+    if not csv_path or not os.path.exists(csv_path):
+        return None
+    df = pd.read_csv(csv_path)
+    if df.empty:
+        return None
+    row = df.iloc[0]
+    best_model = str(row["best_model"])
+    r2 = float(row.get(f"{best_model}_r2", 0))
+
+    if "voxel_mm" in df.columns and "alpha" in df.columns:
+        kind = "alpha"
+    elif "voxel_mm" in df.columns:
+        kind = "voxel"
+    elif "cell_size_mm" in df.columns:
+        kind = "chm"
+    elif "source" in df.columns:
+        kind = "count"
+    elif "percentile" in df.columns:
+        kind = "percentile"
+    else:
+        print(f"  [warn] неизвестный формат CSV: {csv_path}", file=sys.stderr)
+        return None
+
+    params = {}
+    if kind == "voxel":
+        params["voxel_mm"] = float(row["voxel_mm"])
+    elif kind == "alpha":
+        params["voxel_mm"] = float(row.get("voxel_mm", 0))
+        params["alpha"] = float(row["alpha"])
+        params["dz_m"] = float(row.get("layer_dz_mm", 50)) / 1000.0
+    elif kind == "chm":
+        params["cell_size_mm"] = float(row["cell_size_mm"])
+        params["percentile"] = float(row["percentile"])
+    elif kind == "count":
+        params["source"] = str(row["source"])
+    elif kind == "percentile":
+        params["percentile"] = float(row["percentile"])
+
+    stage = None
+    stem = Path(csv_path).stem
+    for s in ("Z31", "Z65"):
+        if f"_{s}_" in f"_{stem}_":
+            stage = s
+            break
+
+    # Всегда берём linear — разница с power копеечная
+    coefs = {"slope": float(row["linear_slope"]),
+             "intercept": float(row["linear_intercept"])}
+    lmse = float(row.get("linear_rmse", 0))
+    lmse_pct = float(row.get("linear_rmse_pct", 0))
+
+    label = _format_label(kind, params)
+    return {
+        "method": kind,
+        "stage": stage,
+        "params": params,
+        "label": label,
+        "x_col": str(row.get("x_col", "?")),
+        "model_type": "linear",
+        "coefs": coefs,
+        "train_r2": round(float(row["linear_r2"]), 4),
+        "train_rmse": round(lmse, 2),
+        "train_rmse_pct": round(lmse_pct, 2),
+    }
+
+
+def _fmt_dict(d: dict) -> str:
+    items = ", ".join(f"{k!r}: {v!r}" for k, v in d.items())
+    return "{" + items + "}"
+
+
+def _format_label(kind: str, params: dict) -> str:
+    if kind == "voxel":
+        return f"size={params['voxel_mm']:g}mm"
+    if kind == "alpha":
+        parts = []
+        if params.get("voxel_mm", 0) > 0:
+            parts.append(f"pre-vox={params['voxel_mm']:g}mm")
+        parts.append(f"a={params['alpha']:g}")
+        parts.append(f"dz={params['dz_m']*1000:g}mm")
+        return " ".join(parts)
+    if kind == "chm":
+        return f"cell={params['cell_size_mm']:g}mm p={params['percentile']:g}"
+    if kind == "count":
+        return f"source={params['source']}"
+    if kind == "percentile":
+        return f"p={params['percentile']:g}"
+    return str(params)
+
+
+def make_models_code(models: list[dict]) -> str:
+    lines = ["MODELS = ["]
+    for m in models:
+        lines.append("    {")
+        lines.append(f'        "method": {m["method"]!r},')
+        lines.append(f'        "stage": {m["stage"]!r},')
+        lines.append(f'        "label": {m["label"]!r},')
+        lines.append(f'        "params": {_fmt_dict(m["params"])},')
+        lines.append(f'        "x_col": {m["x_col"]!r},')
+        lines.append(f'        "model_type": {m["model_type"]!r},')
+        lines.append(f'        "coefs": {_fmt_dict(m["coefs"])},')
+        lines.append(f'        "train_r2": {m["train_r2"]:.4f},')
+        lines.append(f'        "train_rmse": {m["train_rmse"]:.2f},')
+        lines.append(f'        "train_rmse_pct": {m["train_rmse_pct"]:.2f},')
+        lines.append("    },")
+    lines.append("]")
+    return "\n".join(lines) + "\n"
+
+
+PREDICT_TEMPLATE = '''\
+#!/usr/bin/env python3
+"""predict.py -- cгенерирован автоматически, не редактировать.
+
+Запуск:
+    python predict.py --cloud file.pcd
+    python predict.py --list data/list.txt --base-dir data --stage Z31
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import open3d as o3d
+
+from tpcve.cloud.cloud_pipeline import PreprocessConfig, preprocess_cloud
+from tpcve.cloud.volume_methods import voxel_volume
+from tpcve.cloud.geometry import alpha_layered
+from tpcve.methods.chm import chm_volume
+from tpcve.core.io import parse_list_line, stage_from_path
+
+# ---------------------------------------------------------------------------
+# Модельные коэффициенты (сгенерированы из regression CSV)
+# ---------------------------------------------------------------------------
+%s
+
+
+def _apply_model(m: dict, x: float) -> float:
+    mt = m["model_type"]
+    c = m["coefs"]
+    if mt in ("linear", "huber"):
+        return c["slope"] * x + c["intercept"]
+    if mt == "power":
+        return c["a"] * (x ** c["b"]) if x > 0 else float("nan")
+    raise ValueError(f"Unknown model_type: {mt}")
+
+
+def _compute_feature(m: dict, veg: np.ndarray, pre) -> float:
+    kind = m["method"]
+    p = m["params"]
+    if kind == "voxel":
+        vol, _ = voxel_volume(veg, p["voxel_mm"] / 1000.0)
+        return float(vol)
+    if kind == "alpha":
+        pts = veg
+        vm = p.get("voxel_mm", 0)
+        if vm > 0 and len(pts):
+            pcd = o3d.geometry.PointCloud()
+            pcd.points = o3d.utility.Vector3dVector(pts)
+            pcd = pcd.voxel_down_sample(voxel_size=vm / 1000.0)
+            pts = np.asarray(pcd.points)
+        _, vol = alpha_layered(pts, p["alpha"], p["dz_m"], with_rings=False)
+        return float(vol)
+    if kind == "chm":
+        vol, _ = chm_volume(veg, p["cell_size_mm"] / 1000.0, p["percentile"])
+        return float(vol)
+    if kind == "percentile":
+        if len(veg) == 0:
+            return 0.0
+        return float(np.percentile(veg[:, 2], p["percentile"]))
+    if kind == "count":
+        return float(pre.n_input if p.get("source") == "raw" else len(veg))
+    raise ValueError(f"Unknown method: {kind}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args(argv=None):
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--env-file", default=None)
+    pre_args, _ = pre.parse_known_args(argv)
+    if pre_args.env_file and os.path.exists(pre_args.env_file):
+        from dotenv import load_dotenv
+        load_dotenv(pre_args.env_file, override=True)
+    elif os.path.exists(".env"):
+        from dotenv import load_dotenv
+        load_dotenv(".env", override=True)
+
+    p = argparse.ArgumentParser(
+        description="Predict biomass from point cloud using pre-trained model",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--env-file", default=None)
+    p.add_argument("--stage", default=None, choices=["Z31", "Z65", "all"],
+                   help="Filter by growth stage; 'all' = all stages")
+
+    src = p.add_mutually_exclusive_group()
+    src.add_argument("--list", dest="list_file",
+                     help="List file (path + biomass per line)")
+    src.add_argument("--cloud", dest="cloud_file", help="Single cloud file")
+    p.add_argument("--base-dir", default=os.getenv("TPCVE_BASE_DIR", "data"))
+
+    p.add_argument("--units", default=os.getenv("TPCVE_UNITS", "auto"),
+                   choices=["auto", "m", "cm", "mm"])
+    p.add_argument("--flip-z", action="store_true",
+                   default=os.getenv("TPCVE_FLIP_Z", "").lower() in ("1", "true", "yes"))
+    p.add_argument("--downsample", type=float,
+                   default=float(os.getenv("TPCVE_DOWNSAMPLE", "0") or 0))
+    p.add_argument("--sor-neighbors", type=int, default=20)
+    p.add_argument("--sor-std-ratio", type=float,
+                   default=float(os.getenv("TPCVE_SOR_STD_RATIO", "2.0")))
+    p.add_argument("--min-range", type=float,
+                   default=float(os.getenv("TPCVE_MIN_RANGE", "0") or 0))
+    p.add_argument("--height-threshold", type=float, default=0.04)
+    p.add_argument("--div2-z65", action=argparse.BooleanOptionalAction,
+                   default=os.getenv("TPCVE_DIV2_Z65", "true").lower() in ("1", "true", "yes"),
+                   help="Divide Z65 biomass by 2")
+    p.add_argument("--output-json", default=None,
+                   help="Save results as JSON")
+    p.add_argument("--output-errors", default=None,
+                   help="Save per-cloud predictions + errors as CSV (--list mode)")
+
+    args = p.parse_args(argv)
+    if not args.list_file and not args.cloud_file:
+        p.error("Specify --cloud or --list")
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Single cloud
+# ---------------------------------------------------------------------------
+
+_DISPLAY_NAMES = {"voxel": "voxel", "alpha": "alpha", "chm": "chm",
+                  "count": "count", "percentile": "height"}
+
+_UNITS_LABEL = {"voxel": "m\u00b3", "alpha": "m\u00b3", "chm": "m\u00b3",
+                "percentile": "m", "count": "pts"}
+
+
+def _predict_one(veg, pre, stage) -> list[dict]:
+    results = []
+    for m in MODELS:
+        if stage == "all":
+            pass
+        elif stage:
+            if m["stage"] != stage:
+                continue
+        elif m["stage"]:
+            continue
+        x = _compute_feature(m, veg, pre)
+        y = _apply_model(m, x)
+        results.append({**m, "x_pred": x, "y_pred": y})
+    stage_order = {"Z31": 0, "Z65": 1, None: 2}
+    method_order = {"voxel": 0, "alpha": 1, "chm": 2, "height": 3, "count": 4}
+    results.sort(key=lambda r: (stage_order.get(r.get("stage"), 99),
+                                method_order.get(r["method"], 99)))
+    return results
+
+
+def _print_single(rel, pre, results, biomass_gt=None):
+    print(f"Cloud:        {rel}")
+    print(f"Points:       in={pre.n_input}  sor={pre.n_after_sor}  "
+          f"veg={len(pre.vegetation)}")
+    if biomass_gt is not None:
+        print(f"Biomass:      {biomass_gt:.3f} g")
+    print()
+
+    has_gt = biomass_gt is not None
+    if has_gt:
+        h = (f"{'method':<6} | {'params':<28} | {'model':<6} | "
+             f"{'x_pred':>10}     | {'y_pred (g)':>13} | "
+             f"{'abs_err (g)':>14} | {'rel_err':>8} | {'train R\u00b2':>8} | {'RMSE (g)':>9} | {'RMSE%':>7}")
+        sep = "-" * len(h)
+    else:
+        h = (f"{'method':<6} | {'params':<28} | {'model':<6} | "
+             f"{'x_pred':>10}     | {'y_pred (g)':>13} | {'train R\u00b2':>8} | {'RMSE (g)':>9} | {'RMSE%':>7}")
+        sep = "-" * len(h)
+
+    print(h)
+    print(sep)
+
+    prev_stage = None
+    for r in results:
+        unit = _UNITS_LABEL.get(r["method"], "")
+        dname = _DISPLAY_NAMES.get(r["method"], r["method"])
+        x = r["x_pred"]
+        y = r["y_pred"]
+        label = r["label"]
+        s = r.get("stage") or "combined"
+        if s != prev_stage:
+            print(f"--- {s} " + "-" * (len(sep) - len(s) - 5))
+            prev_stage = s
+        if has_gt:
+            ae = y - biomass_gt
+            re = ae / biomass_gt * 100 if biomass_gt > 0 else float("nan")
+            print(f"{dname:<6} | {label:<28} | {r['model_type']:<6} | "
+                  f"{x:>10.4f} {unit:<3} | {y:>13.2f} | {ae:>+14.2f} | "
+                  f"{re:>+7.2f}% | {r['train_r2']:>8.3f} | {r['train_rmse']:>9.2f} | {r['train_rmse_pct']:>6.2f}%")
+        else:
+            print(f"{dname:<6} | {label:<28} | {r['model_type']:<6} | "
+                  f"{x:>10.4f} {unit:<3} | {y:>13.2f} | {r['train_r2']:>8.3f} | {r['train_rmse']:>9.2f} | {r['train_rmse_pct']:>6.2f}%")
+
+def _run_single(cloud_path: Path, args) -> tuple:
+    cfg = PreprocessConfig(
+        units=args.units, flip_z=args.flip_z, downsample=args.downsample,
+        sor_std_ratio=args.sor_std_ratio, sor_neighbors=args.sor_neighbors,
+        min_range=args.min_range, height_threshold=args.height_threshold,
+        verbose=False,
+    )
+    pre = preprocess_cloud(str(cloud_path), cfg)
+    return pre
+
+
+# ---------------------------------------------------------------------------
+# Batch (--list)
+# ---------------------------------------------------------------------------
+
+def _run_list(args) -> int:
+    base_dir = Path(args.base_dir).resolve()
+    stage = args.stage
+
+    items = []
+    with open(args.list_file, encoding="utf-8") as f:
+        for line in f:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            rel, labels = parse_list_line(line)
+            if stage and stage_from_path(rel) != stage:
+                continue
+            bm = float(labels["biomass"])
+            if args.div2_z65 and stage_from_path(rel) == "Z65":
+                bm /= 2.0
+            items.append((base_dir / rel.lstrip("/\\\\"), bm, rel))
+
+    if not items:
+        print("No valid entries in --list")
+        return 1
+
+    if stage == "all":
+        active = list(MODELS)
+    else:
+        active = [m for m in MODELS
+                  if (stage and m["stage"] == stage)
+                  or (not stage and not m["stage"])]
+
+    errs = {id(m): {"m": m, "ae": [], "re": [], "preds": []}
+            for m in active}
+
+    n_total = len(items)
+    for idx, (cloud_path, biomass_gt, rel) in enumerate(items):
+        if not cloud_path.exists():
+            print(f"  [{idx+1}/{n_total}] skip (not found): {rel}",
+                  file=sys.stderr)
+            continue
+        try:
+            cfg = PreprocessConfig(
+                units=args.units, flip_z=args.flip_z,
+                downsample=args.downsample,
+                sor_std_ratio=args.sor_std_ratio,
+                sor_neighbors=args.sor_neighbors,
+                min_range=args.min_range,
+                height_threshold=args.height_threshold,
+                verbose=False,
+            )
+            pre = preprocess_cloud(str(cloud_path), cfg)
+        except Exception as e:
+            print(f"  [{idx+1}/{n_total}] err: {rel}: {e}", file=sys.stderr)
+            continue
+
+        veg = pre.vegetation
+        for m in active:
+            try:
+                x = _compute_feature(m, veg, pre)
+                y = _apply_model(m, x)
+            except Exception:
+                y = float("nan")
+            mid = id(m)
+            errs[mid]["preds"].append({
+                "cloud": rel, "y_true": biomass_gt, "y_pred": y})
+            if math.isfinite(y) and biomass_gt > 0:
+                errs[mid]["ae"].append(abs(y - biomass_gt))
+                errs[mid]["re"].append(abs(y - biomass_gt) / biomass_gt * 100)
+
+        if (idx + 1) % 10 == 0 or idx == n_total - 1:
+            print(f"  [{idx+1}/{n_total}] done")
+
+    # Summary table
+    print(f"\\n{'method':<6} | {'params':<28} | {'model':<6} | {'n':>5} | "
+          f"{'MAE (g)':>10} | {'MRE (%)':>8} | {'RMSE (g)':>10} | {'train R\u00b2':>8} | {'train RMSE (g)':>14} | {'train RMSE%':>11}")
+    print("-" * 125)
+
+    for mid, data in errs.items():
+        m = data["m"]
+        ae = data["ae"]
+        re = data["re"]
+        n = len(ae)
+        mae = sum(ae) / n if n else float("nan")
+        mre = sum(re) / n if n else float("nan")
+        rmse = math.sqrt(sum(a * a for a in ae) / n) if n else float("nan")
+        dname = _DISPLAY_NAMES.get(m["method"], m["method"])
+        print(f"{dname:<6} | {m['label']:<28} | {m['model_type']:<6} | "
+              f"{n:>5} | {mae:>10.2f} | {mre:>7.2f}% | {rmse:>10.2f} | "
+              f"{m['train_r2']:>8.4f} | {m['train_rmse']:>14.2f} | {m['train_rmse_pct']:>10.2f}%")
+
+    # Save per-cloud errors
+    if args.output_errors:
+        rows = []
+        for mid, data in errs.items():
+            m = data["m"]
+            for p in data["preds"]:
+                rows.append({
+                    "method": m["method"],
+                    "params": str(m["params"]),
+                    "model_type": m["model_type"],
+                    "cloud": p["cloud"],
+                    "y_true": p["y_true"],
+                    "y_pred": p["y_pred"],
+                })
+        if rows:
+            out_path = Path(args.output_errors)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(out_path, "w", newline="", encoding="utf-8") as f:
+                w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+                w.writeheader()
+                w.writerows(rows)
+            print(f"\\nSaved per-cloud errors: {out_path}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    base_dir = Path(args.base_dir)
+
+    if args.list_file:
+        return _run_list(args)
+
+    if args.cloud_file:
+        cloud_path = Path(args.cloud_file).resolve()
+        biomass_gt = None
+    else:
+        return 1
+
+    try:
+        rel = cloud_path.relative_to(base_dir.resolve())
+    except ValueError:
+        rel = cloud_path
+
+    pre = _run_single(cloud_path, args)
+    veg = pre.vegetation
+    results = _predict_one(veg, pre, args.stage)
+    _print_single(rel, pre, results, biomass_gt)
+
+    if args.output_json:
+        out = {
+            "cloud": str(rel),
+            "biomass_true": biomass_gt,
+            "n_input": pre.n_input,
+            "n_after_sor": pre.n_after_sor,
+            "n_vegetation": int(len(veg)),
+            "predictions": [
+                {"method": r["method"], "params": r["params"],
+                 "model_type": r["model_type"], "coefs": r["coefs"],
+                 "x_pred": r["x_pred"], "y_pred": r["y_pred"],
+                 "train_r2": r["train_r2"]}
+                for r in results
+            ],
+        }
+        out_path = Path(args.output_json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+        print(f"\\nSaved JSON: {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+METHOD_DIRS = {"voxel": "voxel", "alpha": "alpha", "chm": "chm",
+               "count": "count", "percentile": "percentile"}
+
+
+def _find_csvs(method: str, stage: str | None,
+               results_dir: Path) -> list[Path]:
+    """Найти regression CSV для метода по стадии.
+
+    stage=None — только combined.
+    stage='all' — все стадии (Z31, Z65, combined).
+    stage='Z31'/'Z65' — только указанную.
+    """
+    d = results_dir / METHOD_DIRS[method]
+    if not d.is_dir():
+        return []
+    if stage == "all":
+        stages: list[str | None] = ["Z31", "Z65", None]
+    else:
+        stages = [stage]
+    cands: list[Path] = []
+    for s in stages:
+        best = _pick_best_csv(d, s)
+        if best:
+            cands.append(best)
+    return cands
+
+
+def _pick_best_csv(d: Path, stage: str | None) -> Path | None:
+    cands = []
+    for p in sorted(d.glob("*.csv")):
+        if p.stem.endswith("_test"):
+            continue
+        if stage is None:
+            if "_Z31_" not in p.stem and "_Z65_" not in p.stem:
+                cands.append(p)
+        else:
+            if f"_{stage}_" in f"_{p.stem}_":
+                cands.append(p)
+    if not cands:
+        return None
+    cands.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return cands[0]
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Freeze regression model into standalone predict.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    for method in ("voxel", "alpha", "chm", "percentile", "count"):
+        p.add_argument(f"--{method}-csv", default=None,
+                       help=f"Override: path to {method} regression CSV")
+    p.add_argument("--stage", default=None,
+                   choices=["Z31", "Z65", "all"],
+                   help="Filter regression CSVs by growth stage; 'all' = all stages")
+    p.add_argument("--results-dir", default="results",
+                   help="Results root (default: results)")
+    p.add_argument("--output", default="predict.py", help="Output file path")
+    args = p.parse_args()
+
+    models = []
+
+    for method in ("voxel", "alpha", "chm", "percentile", "count"):
+        explicit = getattr(args, f"{method}_csv")
+        if explicit:
+            csv_paths = [Path(explicit)]
+        else:
+            csv_paths = _find_csvs(method, args.stage,
+                                   Path(args.results_dir) / "regression_csv")
+        if not csv_paths:
+            continue
+        print(f"  {method}:")
+        for csv_path in csv_paths:
+            m = extract_best_row(str(csv_path))
+            if m:
+                models.append(m)
+                s = m.get("stage") or "combined"
+                print(f"    {s}: {csv_path.name} "
+                      f"{m['model_type']} R\u00b2={m['train_r2']}")
+
+    if not models:
+        print("No models found", file=sys.stderr)
+        return 1
+
+    models_code = make_models_code(models)
+    script = PREDICT_TEMPLATE.replace("%s", models_code, 1)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(script, encoding="utf-8")
+    out_path.chmod(0o755)
+    print(f"\nGenerated: {out_path.resolve()}")
+    print(f"  models: {len(models)}")
+    print(f"  size: {out_path.stat().st_size} bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tpcve/cloud/cloud_pipeline.py
+++ b/tpcve/cloud/cloud_pipeline.py
@@ -3,13 +3,17 @@ voxel downsample → SOR → классификация земля/растит�
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+import hashlib
+import json
+from dataclasses import dataclass, asdict
 from pathlib import Path
 
 import numpy as np
 
 from tpcve.cloud.generate_cloud import load_cloud, load_real_cloud
 from tpcve.cloud.geometry import voxel_downsample_np, sor_np
+
+CACHE_VERSION = 1
 
 
 @dataclass
@@ -22,6 +26,7 @@ class PreprocessConfig:
     min_range: float = 0.0
     height_threshold: float = 0.04
     verbose: bool = False
+    cache_dir: str | None = None
 
 
 @dataclass
@@ -37,7 +42,59 @@ def _log(cfg: PreprocessConfig, msg: str) -> None:
         print(msg)
 
 
+def _config_hash(cfg: PreprocessConfig) -> str:
+    raw = json.dumps({k: v for k, v in asdict(cfg).items()
+                      if k not in ("cache_dir", "verbose")},
+                     sort_keys=True, default=str)
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+def _cache_key(path: str) -> str:
+    return hashlib.md5(str(Path(path).resolve()).encode()).hexdigest()
+
+
+def _load_cache(path: str, cfg: PreprocessConfig) -> PreprocessResult | None:
+    if not cfg.cache_dir:
+        return None
+    cache_file = Path(cfg.cache_dir) / f"{_cache_key(path)}.npz"
+    if not cache_file.exists():
+        return None
+    try:
+        data = np.load(cache_file)
+        stored_cfg_hash = str(data.get("config_hash", b""))
+        if stored_cfg_hash != _config_hash(cfg):
+            cache_file.unlink(missing_ok=True)
+            return None
+        return PreprocessResult(
+            vegetation=data["vegetation"],
+            ground=data["ground"],
+            n_input=int(data["n_input"]),
+            n_after_sor=int(data["n_after_sor"]),
+        )
+    except Exception:
+        cache_file.unlink(missing_ok=True)
+        return None
+
+
+def _save_cache(path: str, cfg: PreprocessConfig, res: PreprocessResult) -> None:
+    if not cfg.cache_dir:
+        return
+    cache_dir = Path(cfg.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cache_dir / f"{_cache_key(path)}.npz"
+    np.savez_compressed(cache_file,
+                        vegetation=res.vegetation,
+                        ground=res.ground,
+                        n_input=res.n_input,
+                        n_after_sor=res.n_after_sor,
+                        config_hash=_config_hash(cfg))
+
+
 def preprocess_cloud(path: str, cfg: PreprocessConfig) -> PreprocessResult:
+    cached = _load_cache(path, cfg)
+    if cached is not None:
+        return cached
+
     p = Path(path)
     ext = p.suffix.lower()
 
@@ -81,9 +138,11 @@ def preprocess_cloud(path: str, cfg: PreprocessConfig) -> PreprocessResult:
     _log(cfg, f"  {p.name}: in={n_input} → sor={len(pts_filtered)} "
               f"→ veg={len(vegetation)}")
 
-    return PreprocessResult(
+    res = PreprocessResult(
         vegetation=vegetation,
         ground=ground,
         n_input=n_input,
         n_after_sor=len(pts_filtered),
     )
+    _save_cache(path, cfg, res)
+    return res

--- a/tpcve/cloud/cloud_pipeline.py
+++ b/tpcve/cloud/cloud_pipeline.py
@@ -7,9 +7,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-import open3d as o3d
 
 from tpcve.cloud.generate_cloud import load_cloud, load_real_cloud
+from tpcve.cloud.geometry import voxel_downsample_np, sor_np
 
 
 @dataclass
@@ -62,21 +62,13 @@ def preprocess_cloud(path: str, cfg: PreprocessConfig) -> PreprocessResult:
         dxy = np.linalg.norm(pts[:, :2] - scanner_pos[:2], axis=1)
         pts = pts[dxy >= cfg.min_range]
 
-    pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(pts)
-
     if cfg.downsample > 0:
-        pcd = pcd.voxel_down_sample(voxel_size=cfg.downsample)
+        pts = voxel_downsample_np(pts, cfg.downsample)
 
-    if len(pcd.points) > cfg.sor_neighbors:
-        pcd_sor, _ = pcd.remove_statistical_outlier(
-            nb_neighbors=cfg.sor_neighbors,
-            std_ratio=cfg.sor_std_ratio,
-            print_progress=False,
-        )
-        pts_filtered = np.asarray(pcd_sor.points)
-    else:
-        pts_filtered = np.asarray(pcd.points)
+    if len(pts) > cfg.sor_neighbors:
+        pts = sor_np(pts, cfg.sor_neighbors, cfg.sor_std_ratio)
+
+    pts_filtered = pts
 
     if len(pts_filtered):
         ground_mask = pts_filtered[:, 2] < cfg.height_threshold

--- a/tpcve/cloud/generate_cloud.py
+++ b/tpcve/cloud/generate_cloud.py
@@ -402,7 +402,7 @@ def _read_pcd_np(filepath: str) -> np.ndarray:
     z_idx = fields.index('z')
 
     if data_fmt == 'DATA ascii':
-        data = np.loadtxt(raw[data_off:].decode('ascii').split('\n'))
+        data = np.loadtxt(raw[data_off:].decode('ascii').splitlines())
         if data.ndim == 1:
             data = data.reshape(1, -1)
         return data[:, [x_idx, y_idx, z_idx]].astype(np.float64)
@@ -426,9 +426,20 @@ def _read_pcd_np(filepath: str) -> np.ndarray:
 
 
 def _read_ply_np(filepath: str) -> np.ndarray:
-    """Прочитать ASCII PLY через numpy."""
     with open(filepath, 'rb') as f:
         raw = f.read()
+
+    header_end_raw = raw.find(b'end_header')
+    if header_end_raw == -1:
+        raise ValueError("Invalid PLY: missing end_header")
+    header_raw = raw[:header_end_raw]
+
+    is_ascii = any(
+        line.split() == [b'format', b'ascii', b'1.0']
+        for line in header_raw.split(b'\n')
+    )
+    if not is_ascii:
+        raise ValueError("Only ASCII PLY supported without open3d")
 
     text = raw.decode('ascii')
     lines = text.split('\n')
@@ -437,13 +448,10 @@ def _read_ply_np(filepath: str) -> np.ndarray:
     props = []
     in_vertex = False
     header_end = 0
-    is_ascii = False
 
     for i, line in enumerate(lines):
         s = line.strip()
-        if s == 'format ascii 1.0':
-            is_ascii = True
-        elif s.startswith('element vertex'):
+        if s.startswith('element vertex'):
             in_vertex = True
             vertex_count = int(s.split()[-1])
         elif s.startswith('property') and in_vertex:
@@ -453,9 +461,6 @@ def _read_ply_np(filepath: str) -> np.ndarray:
             break
         else:
             in_vertex = False
-
-    if not is_ascii:
-        raise ValueError("Only ASCII PLY supported without open3d")
 
     data = np.loadtxt(lines[header_end:header_end + vertex_count])
     if data.ndim == 1:

--- a/tpcve/cloud/generate_cloud.py
+++ b/tpcve/cloud/generate_cloud.py
@@ -358,12 +358,121 @@ def load_db3_cloud(filepath):
     return np.vstack(all_points)
 
 
+def _read_pcd_np(filepath: str) -> np.ndarray:
+    """Прочитать PCD файл через numpy (ASCII и binary)."""
+    with open(filepath, 'rb') as f:
+        raw = f.read()
+
+    header_end = raw.find(b'DATA ')
+    if header_end == -1:
+        raise ValueError("Invalid PCD: missing DATA header")
+
+    eol = raw.find(b'\n', header_end)
+    data_fmt = raw[header_end:eol].decode('ascii').strip()
+    data_off = eol + 1
+
+    header = raw[:header_end].decode('ascii')
+    fields = []
+    types = {}
+    sizes = {}
+    width = 0
+    height = 1
+
+    for line in header.split('\n'):
+        parts = line.strip().split()
+        if not parts:
+            continue
+        if parts[0] == 'FIELDS':
+            fields = parts[1:]
+        elif parts[0] == 'TYPE':
+            for i, t in enumerate(parts[1:]):
+                if i < len(fields):
+                    types[fields[i]] = t
+        elif parts[0] == 'SIZE':
+            for i, s in enumerate(parts[1:]):
+                if i < len(fields):
+                    sizes[fields[i]] = int(s)
+        elif parts[0] == 'WIDTH':
+            width = int(parts[1])
+        elif parts[0] == 'HEIGHT':
+            height = int(parts[1])
+
+    x_idx = fields.index('x')
+    y_idx = fields.index('y')
+    z_idx = fields.index('z')
+
+    if data_fmt == 'DATA ascii':
+        data = np.loadtxt(raw[data_off:].decode('ascii').split('\n'))
+        if data.ndim == 1:
+            data = data.reshape(1, -1)
+        return data[:, [x_idx, y_idx, z_idx]].astype(np.float64)
+
+    if data_fmt != 'DATA binary':
+        raise ValueError(f"Unsupported PCD format: {data_fmt}")
+
+    n_points = width * height
+    DTYPE_MAP = {
+        ('F', 4): np.float32, ('F', 8): np.float64,
+        ('I', 1): np.int8, ('I', 2): np.int16, ('I', 4): np.int32,
+        ('U', 1): np.uint8, ('U', 2): np.uint16, ('U', 4): np.uint32,
+    }
+    dt_list = []
+    for f in fields:
+        key = (types.get(f, 'F'), sizes.get(f, 4))
+        dt_list.append(DTYPE_MAP.get(key, np.float32))
+    dt = np.dtype(list(zip(fields, dt_list)))
+    parsed = np.frombuffer(raw[data_off:], dtype=dt, count=n_points)
+    return np.column_stack([parsed['x'], parsed['y'], parsed['z']]).astype(np.float64)
+
+
+def _read_ply_np(filepath: str) -> np.ndarray:
+    """Прочитать ASCII PLY через numpy."""
+    with open(filepath, 'rb') as f:
+        raw = f.read()
+
+    text = raw.decode('ascii')
+    lines = text.split('\n')
+
+    vertex_count = 0
+    props = []
+    in_vertex = False
+    header_end = 0
+    is_ascii = False
+
+    for i, line in enumerate(lines):
+        s = line.strip()
+        if s == 'format ascii 1.0':
+            is_ascii = True
+        elif s.startswith('element vertex'):
+            in_vertex = True
+            vertex_count = int(s.split()[-1])
+        elif s.startswith('property') and in_vertex:
+            props.append(s.split()[-1])
+        elif s == 'end_header':
+            header_end = i + 1
+            break
+        else:
+            in_vertex = False
+
+    if not is_ascii:
+        raise ValueError("Only ASCII PLY supported without open3d")
+
+    data = np.loadtxt(lines[header_end:header_end + vertex_count])
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+
+    x_idx = props.index('x')
+    y_idx = props.index('y')
+    z_idx = props.index('z')
+    return data[:, [x_idx, y_idx, z_idx]].astype(np.float64)
+
+
 def load_real_cloud(filepath, units='auto', verbose=True):
     """
     Загрузка реального облака точек из различных форматов.
 
     Поддерживаемые форматы:
-    - PCD, PLY, XYZ, PTS (через Open3D)
+    - PCD (ASCII + binary), PLY (ASCII), XYZ, PTS, TXT (через numpy)
     - LAS, LAZ (через laspy, если установлен)
     - DB3, ROS 2 bag (через rosbags, если установлен)
 
@@ -382,8 +491,6 @@ def load_real_cloud(filepath, units='auto', verbose=True):
             'units_detected': str (если units='auto')
         }
     """
-    import open3d as o3d
-
     ext = Path(filepath).suffix.lower()
 
     # LAS/LAZ через laspy
@@ -395,10 +502,20 @@ def load_real_cloud(filepath, units='auto', verbose=True):
         except ImportError:
             raise ImportError("Для LAS/LAZ нужен laspy: pip install laspy")
 
-    # Остальные форматы через Open3D
-    elif ext in ['.pcd', '.ply', '.xyz', '.pts', '.txt']:
-        pcd = o3d.io.read_point_cloud(filepath)
-        points = np.asarray(pcd.points)
+    # PCD через numpy
+    elif ext == '.pcd':
+        points = _read_pcd_np(filepath)
+
+    # PLY (ASCII) через numpy
+    elif ext == '.ply':
+        points = _read_ply_np(filepath)
+
+    # XYZ/PTS/TXT — простые ASCII с колонками
+    elif ext in ['.xyz', '.pts', '.txt']:
+        data = np.loadtxt(filepath)
+        if data.ndim == 1:
+            data = data.reshape(1, -1)
+        points = data[:, :3].astype(np.float64)
 
     # ROS 2 bag (.db3)
     elif ext == '.db3':

--- a/tpcve/cloud/geometry.py
+++ b/tpcve/cloud/geometry.py
@@ -12,16 +12,27 @@
 """
 from __future__ import annotations
 
-import alphashape
 import numpy as np
-import open3d as o3d
 from scipy.spatial import ConvexHull, Delaunay
 from scipy.spatial.qhull import QhullError
 
 
 # --- downsample ---
 
+def voxel_downsample_np(points: np.ndarray, voxel_m: float) -> np.ndarray:
+    if len(points) == 0 or voxel_m <= 0:
+        return points
+    voxel_indices = np.floor(points / voxel_m).astype(np.int64)
+    _, inverse, counts = np.unique(voxel_indices, axis=0,
+                                   return_inverse=True, return_counts=True)
+    centroids = np.zeros((len(counts), 3), dtype=np.float64)
+    np.add.at(centroids, inverse, points)
+    centroids /= counts[:, np.newaxis]
+    return centroids
+
+
 def voxel_downsample(points: np.ndarray, voxel_m: float) -> np.ndarray:
+    import open3d as o3d
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(points)
     return np.asarray(pcd.voxel_down_sample(voxel_size=voxel_m).points)
@@ -35,9 +46,8 @@ def random_downsample(points: np.ndarray, n: int, seed: int) -> np.ndarray:
 
 
 def sor(points: np.ndarray, nb_neighbors: int, std_ratio: float) -> np.ndarray:
-    """Statistical Outlier Removal: выкидывает точки, чьё среднее расстояние до
-    nb_neighbors соседей отстоит от общего среднего больше чем на std_ratio·σ.
-    Облака не больше nb_neighbors возвращаются как есть."""
+    """Statistical Outlier Removal с open3d (тяжёлый импорт)."""
+    import open3d as o3d
     if len(points) <= nb_neighbors:
         return points
     pcd = o3d.geometry.PointCloud()
@@ -46,6 +56,19 @@ def sor(points: np.ndarray, nb_neighbors: int, std_ratio: float) -> np.ndarray:
         nb_neighbors=nb_neighbors, std_ratio=std_ratio, print_progress=False
     )
     return np.asarray(pcd_sor.points)
+
+
+def sor_np(points: np.ndarray, nb_neighbors: int, std_ratio: float) -> np.ndarray:
+    """Statistical Outlier Removal через scipy KDTree (без open3d)."""
+    if len(points) <= nb_neighbors:
+        return points
+    from scipy.spatial import KDTree
+    k = min(nb_neighbors + 1, len(points))
+    tree = KDTree(points)
+    distances, _ = tree.query(points, k=k)
+    avg_distances = distances[:, 1:].mean(axis=1)
+    mu, sigma = avg_distances.mean(), avg_distances.std()
+    return points[avg_distances <= mu + std_ratio * sigma]
 
 
 # --- alpha-shape геометрия ---
@@ -64,6 +87,7 @@ def alpha_mesh(points: np.ndarray, alpha: float):
         except QhullError:
             return None, None, 0.0
         return points[hull.vertices], hull.simplices, float(hull.volume)
+    import alphashape
     shape = alphashape.alphashape(points, alpha)
     verts = getattr(shape, "vertices", None)
     faces = getattr(shape, "faces", None)
@@ -154,6 +178,7 @@ def alpha_layered(points: np.ndarray, alpha: float, dz: float,
         if len(layer_xy) < 3:
             continue
         if with_rings:
+            import alphashape
             polygon = alphashape.alphashape(layer_xy, alpha)
             area = float(getattr(polygon, "area", 0.0) or 0.0)
             rings = _polygon_rings(polygon) if area > 0 else []

--- a/tpcve/cloud/volume_methods.py
+++ b/tpcve/cloud/volume_methods.py
@@ -6,7 +6,6 @@
 """
 from __future__ import annotations
 
-import alphashape
 import numpy as np
 from scipy.spatial import ConvexHull
 
@@ -46,6 +45,7 @@ def _subsample(points: np.ndarray, limit: int = MAX_ALPHA_POINTS,
 def alpha_shape_volume(points: np.ndarray, alpha: float) -> float:
     if len(points) < 4:
         return 0.0
+    import alphashape
     shape = alphashape.alphashape(_subsample(points), alpha)
     return getattr(shape, "volume", 0.0)
 
@@ -54,6 +54,7 @@ def alpha2d_height_volume(points: np.ndarray, alpha: float) -> float:
     """2D alpha shape по проекции на XY × высота (z_max - z_min)."""
     if len(points) < 3:
         return 0.0
+    import alphashape
     shape = alphashape.alphashape(_subsample(points[:, :2]), alpha)
     area = getattr(shape, "area", 0.0)
     height = float(points[:, 2].max() - points[:, 2].min())

--- a/tpcve/core/args.py
+++ b/tpcve/core/args.py
@@ -52,6 +52,8 @@ def add_common_batch_args(p: argparse.ArgumentParser, *,
     p.add_argument("--height-threshold", type=float,
                    default=float(os.getenv("TPCVE_HEIGHT_THRESHOLD", "0.04")),
                    help="Порог высоты для отделения земли от растительности (м)")
+    p.add_argument("--preprocess-cache", default=None,
+                   help="Dir to cache preprocessed clouds (speeds up multi-method runs)")
     p.add_argument("-v", "--verbose", action="store_true")
     p.add_argument("--resume", action="store_true")
     p.add_argument("--limit", type=int, default=None)
@@ -71,7 +73,7 @@ def preprocess_config_from_args(a) -> PreprocessConfig:
         units=a.units, flip_z=a.flip_z, downsample=a.downsample,
         sor_std_ratio=a.sor_std_ratio, sor_neighbors=a.sor_neighbors,
         min_range=a.min_range, height_threshold=a.height_threshold,
-        verbose=a.verbose,
+        verbose=a.verbose, cache_dir=getattr(a, "preprocess_cache", None),
     )
 
 

--- a/tpcve/methods/alpha.py
+++ b/tpcve/methods/alpha.py
@@ -20,11 +20,10 @@ import csv
 import os
 
 import numpy as np
-import open3d as o3d
 from tqdm import tqdm
 
 from tpcve.cloud.cloud_pipeline import PreprocessConfig, preprocess_cloud
-from tpcve.cloud.geometry import _compute_one, random_downsample, voxel_downsample
+from tpcve.cloud.geometry import _compute_one, random_downsample, voxel_downsample_np
 from tools.autoname import build_name, default_path
 from tpcve import core
 
@@ -95,10 +94,10 @@ def add_analyze_args(p: argparse.ArgumentParser) -> None:
 
 
 def auto_voxel_mm(points: np.ndarray) -> float:
-    pcd = o3d.geometry.PointCloud()
-    pcd.points = o3d.utility.Vector3dVector(points)
-    nn = np.asarray(pcd.compute_nearest_neighbor_distance())
-    return float(nn.mean()) * 1000
+    from scipy.spatial import KDTree
+    tree = KDTree(points)
+    nn_dist, _ = tree.query(points, k=2)
+    return float(nn_dist[:, 1].mean()) * 1000
 
 
 def build_tasks(item: core.InputItem, points: np.ndarray, cfg: AlphaConfig,
@@ -119,7 +118,7 @@ def build_tasks(item: core.InputItem, points: np.ndarray, cfg: AlphaConfig,
     rows: dict[tuple[str, float, float, object], dict] = {}
     for size_mm in sizes_mm:
         size_m = size_mm / 1000.0
-        v_pts = points if size_m <= 0 else voxel_downsample(points, size_m)
+        v_pts = points if size_m <= 0 else voxel_downsample_np(points, size_m)
         if len(v_pts) == 0:
             continue
         n_v = len(v_pts)

--- a/uv.lock
+++ b/uv.lock
@@ -53,6 +53,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +720,18 @@ wheels = [
 ]
 
 [[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1110,6 +1131,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pillow"
 version = "12.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1219,6 +1249,46 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1258,6 +1328,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1817,6 +1896,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "nbstripout" },
+    { name = "pyinstaller" },
 ]
 
 [package.metadata]
@@ -1833,7 +1913,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "nbstripout", specifier = ">=0.9.1" }]
+dev = [
+    { name = "nbstripout", specifier = ">=0.9.1" },
+    { name = "pyinstaller", specifier = ">=6.21.0" },
+]
 
 [[package]]
 name = "tqdm"

--- a/uv.lock
+++ b/uv.lock
@@ -681,6 +681,18 @@ wheels = [
 ]
 
 [[package]]
+name = "laspy"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5d/5a540ac25dcc57fa77691363bb753363b192a3759aefef4b40e1250ddb17/laspy-2.7.0.tar.gz", hash = "sha256:f56feb5445e75d6ff12ee814aab6a35339290e75264ff277c6bf553f3025a3f5", size = 1929624, upload-time = "2026-01-14T22:18:42.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/fb/ae27ebca327117e35cc717a3a87afdcbbf10d5aac52e405d16ebe777357e/laspy-2.7.0-py3-none-any.whl", hash = "sha256:15f5344c62a1023461996bdf5d1ba5fdd813e96694a524fee712931134f3792f", size = 86056, upload-time = "2026-01-14T22:18:40.779Z" },
+]
+
+[[package]]
 name = "lz4"
 version = "4.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1928,9 +1940,6 @@ dependencies = [
     { name = "alphashape" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "open3d" },
-    { name = "optuna" },
-    { name = "pytest" },
     { name = "python-dotenv" },
     { name = "rosbags" },
     { name = "scikit-learn" },
@@ -1941,6 +1950,12 @@ dependencies = [
 dev = [
     { name = "nbstripout" },
     { name = "pyinstaller" },
+    { name = "pytest" },
+]
+extra = [
+    { name = "laspy" },
+    { name = "open3d" },
+    { name = "optuna" },
 ]
 
 [package.metadata]
@@ -1948,9 +1963,6 @@ requires-dist = [
     { name = "alphashape", specifier = ">=1.3.1" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.4.4" },
-    { name = "open3d", specifier = ">=0.19.0" },
-    { name = "optuna", specifier = ">=4.8.0" },
-    { name = "pytest", specifier = ">=9.1.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rosbags", specifier = ">=0.11.0" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
@@ -1961,6 +1973,12 @@ requires-dist = [
 dev = [
     { name = "nbstripout", specifier = ">=0.9.1" },
     { name = "pyinstaller", specifier = ">=6.21.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+]
+extra = [
+    { name = "laspy", specifier = ">=2.5.4" },
+    { name = "open3d", specifier = ">=0.19.0" },
+    { name = "optuna", specifier = ">=4.8.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -496,6 +496,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1249,6 +1258,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyinstaller"
 version = "6.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1307,6 +1334,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/3d092aa20efaedacb89c3221a92c6491be5b28f618a2c36b52b53e7446c2/pyquaternion-0.9.9.tar.gz", hash = "sha256:b1f61af219cb2fe966b5fb79a192124f2e63a3f7a777ac3cadf2957b1a81bea8", size = 15530, upload-time = "2020-10-05T01:31:30.327Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b3/d8482e8cacc8ea15a356efea13d22ce1c5914a9ee36622ba250523240bf2/pyquaternion-0.9.9-py3-none-any.whl", hash = "sha256:e65f6e3f7b1fdf1a9e23f82434334a1ae84f14223eee835190cd2e841f8172ec", size = 14361, upload-time = "2020-10-05T01:31:37.575Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1887,6 +1930,7 @@ dependencies = [
     { name = "numpy" },
     { name = "open3d" },
     { name = "optuna" },
+    { name = "pytest" },
     { name = "python-dotenv" },
     { name = "rosbags" },
     { name = "scikit-learn" },
@@ -1906,6 +1950,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.4" },
     { name = "open3d", specifier = ">=0.19.0" },
     { name = "optuna", specifier = ">=4.8.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "rosbags", specifier = ">=0.11.0" },
     { name = "scikit-learn", specifier = ">=1.8.0" },


### PR DESCRIPTION
- feat(tools): freeze regression model into standalone predict.py
- refactor: replace open3d with numpy in cloud modules
- ci: add cross-platform predict build with upx+strip
- fix: handle \r\n in PCD parser, detect binary PLY before decode
- refactor: remove unused best_model and r2 vars
- refactor: remove open3d dependency from alpha method
- refactor: migrate experiments from open3d to numpy variants
- ci: generate predict.py before pyinstaller build
- chore: add pytest dev dependency
- ci: pin os versions, add uv package cache
- fix: correct Windows OS name in .exe suffix condition
- ci: split pipeline job, use setup-uv, add smoke test
- refactor: split dev deps into dev/extra groups, add laspy, drop --collect-all numpy
- cloud_pipeline: cache preprocessed vegetation to disk
